### PR TITLE
fix: concurrency safety — task lifecycle, ContextVar resolution, Clock abstraction

### DIFF
--- a/packages/pykit-component/src/pykit_component/registry.py
+++ b/packages/pykit-component/src/pykit_component/registry.py
@@ -33,10 +33,21 @@ class Registry:
         self._lookup[name] = entry
 
     async def start_all(self) -> None:
-        """Start all components in registration order."""
-        for entry in self._entries:
-            await entry.component.start()
-            entry.started = True
+        """Start all components in registration order. Rolls back on partial failure."""
+        import contextlib
+
+        started: list[_Entry] = []
+        try:
+            for entry in self._entries:
+                await entry.component.start()
+                entry.started = True
+                started.append(entry)
+        except Exception:
+            for e in reversed(started):
+                with contextlib.suppress(Exception):
+                    await e.component.stop()
+                e.started = False
+            raise
 
     async def stop_all(self) -> None:
         """Stop all started components in reverse registration order."""
@@ -51,7 +62,7 @@ class Registry:
             finally:
                 entry.started = False
         if errors:
-            raise RuntimeError(f"shutdown errors: {errors}")
+            raise ExceptionGroup("errors during stop_all", errors)
 
     async def health_all(self) -> list[Health]:
         """Return health status for every registered component."""

--- a/packages/pykit-di/src/pykit_di/container.py
+++ b/packages/pykit-di/src/pykit_di/container.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import enum
 import threading
 from collections.abc import Callable
+from contextvars import ContextVar
 from typing import Any, TypeVar
 
 T = TypeVar("T")
+
+_resolving_var: ContextVar[frozenset[str]] = ContextVar("_resolving", default=frozenset())
 
 
 class RegistrationMode(enum.StrEnum):
@@ -51,7 +54,24 @@ class Container:
     def __init__(self) -> None:
         self._registrations: dict[str, _Registration] = {}
         self._lock = threading.Lock()
-        self._resolving: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # ContextVar-based cycle detection helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_resolving() -> frozenset[str]:
+        return _resolving_var.get()
+
+    @staticmethod
+    def _enter_resolving(name: str) -> None:
+        current = _resolving_var.get()
+        _resolving_var.set(current | {name})
+
+    @staticmethod
+    def _exit_resolving(name: str) -> None:
+        current = _resolving_var.get()
+        _resolving_var.set(current - {name})
 
     # ------------------------------------------------------------------
     # Registration
@@ -109,17 +129,16 @@ class Container:
                 return self._check_type(name, reg.instance, type_hint)
 
             # Circular dependency guard
-            if name in self._resolving:
+            if name in self._get_resolving():
                 raise CircularDependencyError(f"Circular dependency detected while resolving '{name}'")
-            self._resolving.add(name)
+            self._enter_resolving(name)
 
         # Factory call outside lock to avoid deadlock, but guard is set.
         try:
             assert reg.factory is not None
             instance = reg.factory()
         finally:
-            with self._lock:
-                self._resolving.discard(name)
+            self._exit_resolving(name)
 
         with self._lock:
             reg.instance = instance
@@ -161,7 +180,6 @@ class Container:
         """Remove all registrations and reset internal state."""
         with self._lock:
             self._registrations.clear()
-            self._resolving.clear()
 
     # ------------------------------------------------------------------
     # Helpers

--- a/packages/pykit-resilience/src/pykit_resilience/retry.py
+++ b/packages/pykit-resilience/src/pykit_resilience/retry.py
@@ -72,4 +72,4 @@ async def retry[T](
                 cfg.on_retry(attempt, exc, backoff)
             await asyncio.sleep(backoff)
 
-    raise RetryExhaustedError(cfg.max_attempts, last_error)  # type: ignore[arg-type]
+    raise RetryExhaustedError(cfg.max_attempts, last_error) from last_error  # type: ignore[arg-type]

--- a/packages/pykit-server-middleware/src/pykit_server_middleware/ratelimit.py
+++ b/packages/pykit-server-middleware/src/pykit_server_middleware/ratelimit.py
@@ -106,12 +106,17 @@ class RateLimiter:
         if self._cleanup_task is None:
             self._cleanup_task = asyncio.ensure_future(self._cleanup())
 
-    def stop(self) -> None:
-        """Cancel the background cleanup task."""
+    async def stop(self) -> None:
+        """Cancel and await the background cleanup task."""
         self._stop_event.set()
         if self._cleanup_task is not None:
             self._cleanup_task.cancel()
-            self._cleanup_task = None
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._cleanup_task = None
 
     def allow(self, key: str, rpm: int) -> tuple[bool, int, int, float, int]:
         """Check whether a request is allowed.

--- a/packages/pykit-server/src/pykit_server/base.py
+++ b/packages/pykit-server/src/pykit_server/base.py
@@ -77,6 +77,7 @@ class BaseServer:
         self._server: grpc.aio.Server | None = None
         self._health_servicer: health.HealthServicer | None = None
         self._shutdown_event = asyncio.Event()
+        self._stop_task: asyncio.Task[None] | None = None
         self.logger = log.get_logger(__name__)
 
     @property
@@ -148,7 +149,12 @@ class BaseServer:
         """Install signal handlers for graceful shutdown."""
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, lambda: asyncio.create_task(self.stop()))
+            loop.add_signal_handler(sig, self._schedule_stop)
+
+    def _schedule_stop(self) -> None:
+        """Schedule stop() as a task, storing the reference to prevent GC."""
+        if self._stop_task is None or self._stop_task.done():
+            self._stop_task = asyncio.create_task(self.stop())
 
     @property
     def health_servicer(self) -> health.HealthServicer | None:

--- a/packages/pykit-util/src/pykit_util/__init__.py
+++ b/packages/pykit-util/src/pykit_util/__init__.py
@@ -2,6 +2,7 @@
 
 __version__ = "0.1.0"
 
+from pykit_util.clock import Clock, FakeClock, SystemClock
 from pykit_util.collections import chunk, first, flatten, group_by, unique
 from pykit_util.merge import deep_merge
 from pykit_util.parse import mask_secret, parse_bool, parse_size
@@ -9,6 +10,10 @@ from pykit_util.sanitize import is_safe_string, sanitize_env_value, sanitize_str
 from pykit_util.strings import coalesce, slug, truncate
 
 __all__ = [
+    # clock
+    "Clock",
+    "FakeClock",
+    "SystemClock",
     # collections
     "chunk",
     # strings

--- a/packages/pykit-util/src/pykit_util/clock.py
+++ b/packages/pykit-util/src/pykit_util/clock.py
@@ -1,0 +1,38 @@
+"""Deterministic clock abstraction for testable time-dependent code."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """Protocol for clock implementations — enables deterministic testing."""
+
+    def now(self) -> datetime:
+        """Return the current UTC time."""
+        ...
+
+
+class SystemClock:
+    """Real clock backed by ``datetime.now(UTC)``."""
+
+    def now(self) -> datetime:
+        return datetime.now(tz=timezone.utc)
+
+
+class FakeClock:
+    """Deterministic clock for tests. Starts at a fixed time; advance manually."""
+
+    def __init__(self, initial: datetime | None = None) -> None:
+        self._now = initial or datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def now(self) -> datetime:
+        return self._now
+
+    def advance(self, **kwargs: int) -> None:
+        """Advance time by the given timedelta kwargs (e.g., seconds=30)."""
+        self._now += timedelta(**kwargs)
+
+    def set(self, dt: datetime) -> None:
+        """Set absolute time."""
+        self._now = dt


### PR DESCRIPTION
## Summary

This PR addresses multiple concurrency safety issues found in the codebase.

### Changes

**#18 — `Component.start_all` rollback on partial failure**
- `start_all` now tracks started components and rolls back (stops them in reverse) if any component fails to start
- `stop_all` now raises `ExceptionGroup` instead of `RuntimeError` to surface all stop errors

**#19 — `Container._resolving` ContextVar isolation**
- Replaced per-instance `_resolving: set[str]` with a module-level `ContextVar[frozenset[str]]`
- Cycle detection is now isolated per async task/coroutine context, preventing cross-task interference

**#20 — Fix fire-and-forget `asyncio.create_task(self.stop())`**
- Signal handler now calls `self._schedule_stop()` which stores the task in `self._stop_task`
- Prevents the GC from collecting the task before it completes

**#21 — Fix `RateLimiter.stop()` drops cleanup task reference**
- `stop()` is now `async` and properly `await`s the cleanup task with `CancelledError` handling
- Task reference is cleared in a `finally` block after awaiting

**#14 — Exception chaining**
- `raise RetryExhaustedError(...)` now uses `from last_error` to preserve the exception chain

**#42 — `Clock` protocol for testable time**
- Added `clock.py` to `pykit-util` with `Clock` (Protocol), `SystemClock` (real time), and `FakeClock` (deterministic for tests)
- Exported from `pykit_util.__init__`

Fixes #14
Fixes #18
Fixes #19
Fixes #20
Fixes #21
Fixes #42