### PR TITLE
feat: align L2 modules (component, hook, di, provider, bootstrap)

### DIFF
--- a/packages/pykit-bootstrap/pyproject.toml
+++ b/packages/pykit-bootstrap/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.13"
 dependencies = [
     "pykit-component",
     "pykit-errors",
+    "pykit-hook",
     "pykit-logging",
 ]
 

--- a/packages/pykit-bootstrap/src/pykit_bootstrap/__init__.py
+++ b/packages/pykit-bootstrap/src/pykit_bootstrap/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pykit_bootstrap.app import App
 from pykit_bootstrap.config import AppConfig, DefaultAppConfig, Environment, LoggingConfig, ServiceConfig
-from pykit_bootstrap.lifecycle import Hook, Lifecycle
+from pykit_bootstrap.lifecycle import EVENT_READY, EVENT_START, EVENT_STOP, Hook, Lifecycle, LifecycleEvent
 from pykit_component import Component, Health, HealthStatus, Registry
 
 __all__ = [
@@ -13,10 +13,14 @@ __all__ = [
     "Component",
     "DefaultAppConfig",
     "Environment",
+    "EVENT_READY",
+    "EVENT_START",
+    "EVENT_STOP",
     "Health",
     "HealthStatus",
     "Hook",
     "Lifecycle",
+    "LifecycleEvent",
     "LoggingConfig",
     "Registry",
     "ServiceConfig",

--- a/packages/pykit-bootstrap/src/pykit_bootstrap/app.py
+++ b/packages/pykit-bootstrap/src/pykit_bootstrap/app.py
@@ -5,31 +5,45 @@ from __future__ import annotations
 import asyncio
 import signal
 from collections.abc import Awaitable, Callable
-from typing import Self
+from typing import Protocol, Self
 
 from pykit_bootstrap.config import AppConfig
 from pykit_bootstrap.lifecycle import Hook, Lifecycle
 from pykit_component import Component, Registry
+from pykit_hook import Registry as HookRegistry
 from pykit_logging import get_logger, setup_logging
 
-logger = get_logger("pykit_bootstrap")
+
+class LoggerLike(Protocol):
+    """Logger contract used by bootstrap."""
+
+    def info(self, event: str, /, **kwargs: object) -> None: ...
+
+    def error(self, event: str, /, **kwargs: object) -> None: ...
 
 
 class App:
     """Async application with managed lifecycle phases.
 
-    Lifecycle (``run``):
-        log startup → start components → configure hooks → start hooks →
-        ready check → ready hooks → wait for SIGINT/SIGTERM →
-        stop hooks → stop components → log shutdown
+    Lifecycle (``run``): configure hooks → start components → start hooks →
+    ready check → ready hooks → wait for SIGINT/SIGTERM → stop hooks →
+    stop components.
 
     For finite CLI tasks use ``run_task`` instead.
     """
 
-    def __init__(self, config: AppConfig, *, graceful_timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        config: AppConfig,
+        *,
+        graceful_timeout: float = 30.0,
+        logger: LoggerLike | None = None,
+    ) -> None:
         self._config = config
         self._graceful_timeout = graceful_timeout
-        self._lifecycle = Lifecycle()
+        self._logger = logger or get_logger("pykit_bootstrap")
+        self._hooks = HookRegistry()
+        self._lifecycle = Lifecycle(self._hooks)
         self._registry = Registry()
         self._ready_check: Callable[[], Awaitable[None]] | None = None
 
@@ -55,23 +69,27 @@ class App:
         return self
 
     def on_configure(self, hook: Hook) -> Self:
-        """Register a hook to run after components start but before start hooks."""
+        """Register a hook to run before components start."""
         self._lifecycle.on_configure(hook)
         return self
 
     def on_start(self, hook: Hook) -> Self:
+        """Register a hook to run after components start."""
         self._lifecycle.on_start(hook)
         return self
 
     def on_ready(self, hook: Hook) -> Self:
+        """Register a hook to run after the ready check passes."""
         self._lifecycle.on_ready(hook)
         return self
 
     def on_stop(self, hook: Hook) -> Self:
+        """Register a hook to run during shutdown."""
         self._lifecycle.on_stop(hook)
         return self
 
     def set_ready_check(self, fn: Callable[[], Awaitable[None]]) -> Self:
+        """Set the readiness probe executed before ready hooks."""
         self._ready_check = fn
         return self
 
@@ -81,38 +99,46 @@ class App:
         """Execute the full service lifecycle, blocking until a signal."""
         sc = self._config.service_config
         self._setup_logging()
-        logger.info(
+        self._logger.info(
             "Starting application",
             name=sc.name,
             version=sc.version,
             env=sc.environment.value,
         )
 
+        body_error: BaseException | None = None
         try:
-            await self._registry.start_all()
-            await self._lifecycle.run_configure_hooks()
-            await self._lifecycle.run_start_hooks()
-            await self._run_ready_check()
-            await self._lifecycle.run_ready_hooks()
-
-            logger.info("Application ready — waiting for shutdown signal")
+            await self._startup()
+            self._logger.info("Application ready — waiting for shutdown signal", name=sc.name)
             await self._wait_for_signal()
+        except BaseException as exc:
+            body_error = exc
+            raise
         finally:
-            await self._shutdown()
+            await self._shutdown(suppress_errors=body_error is not None)
 
     # -- run_task (finite CLI jobs) ------------------------------------------
 
     async def run_task(self, fn: Callable[[], Awaitable[None]]) -> None:
-        """Run *fn* between start and stop hooks (no signal wait)."""
+        """Run *fn* between startup and shutdown (no signal wait)."""
+        sc = self._config.service_config
         self._setup_logging()
+        self._logger.info(
+            "Starting application",
+            name=sc.name,
+            version=sc.version,
+            env=sc.environment.value,
+        )
 
+        body_error: BaseException | None = None
         try:
-            await self._registry.start_all()
-            await self._lifecycle.run_configure_hooks()
-            await self._lifecycle.run_start_hooks()
+            await self._startup()
             await fn()
+        except BaseException as exc:
+            body_error = exc
+            raise
         finally:
-            await self._shutdown()
+            await self._shutdown(suppress_errors=body_error is not None)
 
     # -- internals -----------------------------------------------------------
 
@@ -125,6 +151,23 @@ class App:
             level = sc.logging.level
             fmt = sc.logging.format
         setup_logging(level=level, log_format=fmt, service_name=sc.name)
+
+    async def _startup(self) -> None:
+        context = self._lifecycle_context()
+        sc = self._config.service_config
+        await self._lifecycle.run_configure_hooks(app_name=sc.name, context=context)
+        await self._registry.start_all()
+        await self._lifecycle.run_start_hooks(app_name=sc.name, context=context)
+        await self._run_ready_check()
+        await self._lifecycle.run_ready_hooks(app_name=sc.name, context=context)
+
+    def _lifecycle_context(self) -> dict[str, object]:
+        return {
+            "app": self,
+            "config": self._config,
+            "logger": self._logger,
+            "registry": self._registry,
+        }
 
     async def _run_ready_check(self) -> None:
         if self._ready_check is not None:
@@ -143,15 +186,25 @@ class App:
             for sig in (signal.SIGINT, signal.SIGTERM):
                 loop.remove_signal_handler(sig)
 
-    async def _shutdown(self) -> None:
+    async def _shutdown(self, *, suppress_errors: bool) -> None:
         sc = self._config.service_config
-        logger.info("Shutting down", name=sc.name)
+        self._logger.info("Shutting down", name=sc.name)
         try:
             await asyncio.wait_for(
-                self._lifecycle.run_stop_hooks(),
+                self._lifecycle.run_stop_hooks(
+                    app_name=sc.name,
+                    context=self._lifecycle_context(),
+                ),
                 timeout=self._graceful_timeout,
             )
         except TimeoutError:
-            logger.error("Graceful shutdown timed out", timeout=self._graceful_timeout)
+            self._logger.error("Graceful shutdown timed out", timeout=self._graceful_timeout)
+        except Exception:
+            if not suppress_errors:
+                raise
         finally:
-            await self._registry.stop_all()
+            try:
+                await self._registry.stop_all()
+            except Exception:
+                if not suppress_errors:
+                    raise

--- a/packages/pykit-bootstrap/src/pykit_bootstrap/lifecycle.py
+++ b/packages/pykit-bootstrap/src/pykit_bootstrap/lifecycle.py
@@ -1,58 +1,152 @@
-"""Lifecycle hook management."""
+"""Lifecycle hook management backed by ``pykit_hook.Registry``."""
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
-Hook = Callable[[], Awaitable[None]]
+from pykit_hook import Action, EventType, HookContext, Registry, Result, continue_
+
+_EVENT_CONFIGURE: EventType = "lifecycle.configure"
+EVENT_START: EventType = "lifecycle.start"
+EVENT_READY: EventType = "lifecycle.ready"
+EVENT_STOP: EventType = "lifecycle.stop"
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """Lifecycle event emitted through the hook registry."""
+
+    type: EventType
+    app_name: str
+
+
+type Hook = (
+    Callable[[], Awaitable[None]]
+    | Callable[[LifecycleEvent], Awaitable[None]]
+    | Callable[[HookContext | None, LifecycleEvent], Awaitable[None]]
+)
 
 
 class Lifecycle:
     """Manages ordered configure, start, ready, and stop hooks.
 
     Configure, start, and ready hooks execute in registration order.
-    Stop hooks execute in **reverse** registration order so that
-    resources are torn down in the opposite order they were set up.
+    Stop hooks execute in reverse registration order so that resources
+    are torn down in the opposite order they were set up.
     """
 
-    def __init__(self) -> None:
-        self._on_configure: list[Hook] = []
-        self._on_start: list[Hook] = []
-        self._on_ready: list[Hook] = []
-        self._on_stop: list[Hook] = []
+    def __init__(self, registry: Registry | None = None) -> None:
+        self._registry = registry or Registry()
 
-    def on_configure(self, hook: Hook) -> None:
+    @property
+    def registry(self) -> Registry:
+        """Return the underlying hook registry."""
+        return self._registry
+
+    def on_configure(self, hook: Hook) -> Callable[[], None]:
         """Register a hook to run during the configure phase."""
-        self._on_configure.append(hook)
+        return self._registry.on(_EVENT_CONFIGURE, self._wrap(hook))
 
-    def on_start(self, hook: Hook) -> None:
+    def on_start(self, hook: Hook) -> Callable[[], None]:
         """Register a hook to run during the start phase."""
-        self._on_start.append(hook)
+        return self._registry.on(EVENT_START, self._wrap(hook))
 
-    def on_ready(self, hook: Hook) -> None:
+    def on_ready(self, hook: Hook) -> Callable[[], None]:
         """Register a hook to run after the ready check passes."""
-        self._on_ready.append(hook)
+        return self._registry.on(EVENT_READY, self._wrap(hook))
 
-    def on_stop(self, hook: Hook) -> None:
+    def on_stop(self, hook: Hook) -> Callable[[], None]:
         """Register a hook to run during shutdown."""
-        self._on_stop.append(hook)
+        return self._registry.on(EVENT_STOP, self._wrap(hook))
 
-    async def run_configure_hooks(self) -> None:
+    async def run_configure_hooks(
+        self,
+        *,
+        app_name: str = "",
+        context: HookContext | None = None,
+    ) -> None:
         """Run all configure hooks in registration order."""
-        for hook in self._on_configure:
-            await hook()
+        await self._emit(LifecycleEvent(type=_EVENT_CONFIGURE, app_name=app_name), context=context)
 
-    async def run_start_hooks(self) -> None:
+    async def run_start_hooks(
+        self,
+        *,
+        app_name: str = "",
+        context: HookContext | None = None,
+    ) -> None:
         """Run all start hooks in registration order."""
-        for hook in self._on_start:
-            await hook()
+        await self._emit(LifecycleEvent(type=EVENT_START, app_name=app_name), context=context)
 
-    async def run_ready_hooks(self) -> None:
+    async def run_ready_hooks(
+        self,
+        *,
+        app_name: str = "",
+        context: HookContext | None = None,
+    ) -> None:
         """Run all ready hooks in registration order."""
-        for hook in self._on_ready:
-            await hook()
+        await self._emit(LifecycleEvent(type=EVENT_READY, app_name=app_name), context=context)
 
-    async def run_stop_hooks(self) -> None:
-        """Run all stop hooks in **reverse** registration order."""
-        for hook in reversed(self._on_stop):
-            await hook()
+    async def run_stop_hooks(
+        self,
+        *,
+        app_name: str = "",
+        context: HookContext | None = None,
+    ) -> None:
+        """Run all stop hooks in reverse registration order."""
+        await self._emit(
+            LifecycleEvent(type=EVENT_STOP, app_name=app_name),
+            context=context,
+            reverse=True,
+        )
+
+    async def _emit(
+        self,
+        event: LifecycleEvent,
+        *,
+        context: HookContext | None = None,
+        reverse: bool = False,
+    ) -> None:
+        result = await self._registry.emit_async(event, context, reverse=reverse)
+        self._raise_for_result(result)
+
+    @staticmethod
+    def _raise_for_result(result: Result) -> None:
+        if result.action == Action.ABORT:
+            if result.error is not None:
+                raise result.error
+            raise RuntimeError(result.reason or "hook execution aborted")
+        if result.error is not None:
+            raise result.error
+
+    @staticmethod
+    def _wrap(hook: Hook) -> Callable[[HookContext | None, LifecycleEvent], Awaitable[Result]]:
+        async def handler(context: HookContext | None, event: LifecycleEvent) -> Result:
+            await Lifecycle._invoke_hook(hook, context, event)
+            return continue_()
+
+        return handler
+
+    @staticmethod
+    async def _invoke_hook(hook: Hook, context: HookContext | None, event: LifecycleEvent) -> None:
+        signature = inspect.signature(hook)
+        positional = [
+            parameter
+            for parameter in signature.parameters.values()
+            if parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        # Dynamic dispatch based on handler arity — call with appropriate args.
+        fn: Callable[..., Awaitable[None]] = hook
+        if any(
+            parameter.kind == inspect.Parameter.VAR_POSITIONAL for parameter in signature.parameters.values()
+        ):
+            await fn(context, event)
+            return
+        if len(positional) >= 2:
+            await fn(context, event)
+            return
+        if len(positional) == 1:
+            await fn(event)
+            return
+        await fn()

--- a/packages/pykit-bootstrap/tests/test_bootstrap.py
+++ b/packages/pykit-bootstrap/tests/test_bootstrap.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
-import os
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from pykit_bootstrap import (
+    EVENT_READY,
+    EVENT_START,
+    EVENT_STOP,
     App,
     AppConfig,
     Component,
@@ -18,409 +20,40 @@ from pykit_bootstrap import (
     HealthStatus,
     Hook,
     Lifecycle,
+    LifecycleEvent,
     LoggingConfig,
     Registry,
     ServiceConfig,
 )
 
-# ---------------------------------------------------------------------------
-# Helper — shortcut for creating DefaultAppConfig
-# ---------------------------------------------------------------------------
 
+@dataclass(slots=True)
+class _LoggerStub:
+    infos: list[tuple[str, dict[str, object]]]
+    errors: list[tuple[str, dict[str, object]]]
 
-def _cfg(name: str = "svc", **kwargs: object) -> DefaultAppConfig:
-    """Create a DefaultAppConfig with the given service name and optional overrides."""
-    svc_kwargs: dict[str, object] = {"name": name}
-    top_kwargs: dict[str, object] = {}
-    svc_fields = {"name", "environment", "version", "debug", "logging"}
-    for k, v in kwargs.items():
-        if k in svc_fields:
-            svc_kwargs[k] = v
-        else:
-            top_kwargs[k] = v
-    return DefaultAppConfig(service=ServiceConfig(**svc_kwargs), **top_kwargs)
+    def info(self, event: str, /, **kwargs: object) -> None:
+        self.infos.append((event, kwargs))
 
-
-# ---------------------------------------------------------------------------
-# Config types
-# ---------------------------------------------------------------------------
-
-
-class TestEnvironment:
-    def test_values(self) -> None:
-        assert Environment.DEVELOPMENT == "development"
-        assert Environment.STAGING == "staging"
-        assert Environment.PRODUCTION == "production"
-
-    def test_str_enum(self) -> None:
-        assert str(Environment.PRODUCTION) == "production"
-
-
-class TestLoggingConfig:
-    def test_defaults(self) -> None:
-        lc = LoggingConfig()
-        assert lc.level == "INFO"
-        assert lc.format == "console"
-
-    def test_frozen(self) -> None:
-        lc = LoggingConfig()
-        with pytest.raises(AttributeError):
-            lc.level = "DEBUG"  # type: ignore[misc]
-
-
-class TestServiceConfig:
-    def test_defaults(self) -> None:
-        sc = ServiceConfig()
-        assert sc.name == ""
-        assert sc.environment == Environment.DEVELOPMENT
-        assert sc.version == "0.0.0"
-        assert sc.debug is False
-        assert isinstance(sc.logging, LoggingConfig)
-
-    def test_custom_values(self) -> None:
-        sc = ServiceConfig(
-            name="api",
-            environment=Environment.PRODUCTION,
-            version="1.2.3",
-            debug=True,
-            logging=LoggingConfig(level="DEBUG", format="json"),
-        )
-        assert sc.name == "api"
-        assert sc.environment == Environment.PRODUCTION
-        assert sc.version == "1.2.3"
-        assert sc.debug is True
-        assert sc.logging.level == "DEBUG"
-        assert sc.logging.format == "json"
-
-    def test_frozen(self) -> None:
-        sc = ServiceConfig(name="x")
-        with pytest.raises(AttributeError):
-            sc.name = "y"  # type: ignore[misc]
-
-
-class TestDefaultAppConfig:
-    def test_defaults(self) -> None:
-        cfg = DefaultAppConfig()
-        assert cfg.service.name == ""
-        assert cfg.service.environment == Environment.DEVELOPMENT
-        assert cfg.graceful_timeout == 30.0
-
-    def test_convenience_properties(self) -> None:
-        cfg = _cfg("svc", version="2.0", environment=Environment.STAGING, debug=True)
-        assert cfg.name == "svc"
-        assert cfg.version == "2.0"
-        assert cfg.env == "staging"
-        assert cfg.debug is True
-
-    def test_service_config_property(self) -> None:
-        sc = ServiceConfig(name="x")
-        cfg = DefaultAppConfig(service=sc)
-        assert cfg.service_config is sc
-
-    def test_apply_defaults_fills_empty_name(self) -> None:
-        cfg = DefaultAppConfig()
-        cfg.apply_defaults()
-        assert cfg.service.name == "unknown"
-
-    def test_apply_defaults_preserves_existing_name(self) -> None:
-        cfg = _cfg("real-svc")
-        cfg.apply_defaults()
-        assert cfg.service.name == "real-svc"
-
-    def test_satisfies_protocol(self) -> None:
-        cfg = _cfg("proto-test")
-        assert isinstance(cfg, AppConfig)
-
-
-# ---------------------------------------------------------------------------
-# Lifecycle
-# ---------------------------------------------------------------------------
-
-
-class TestLifecycle:
-    async def test_start_hooks_run_in_order(self) -> None:
-        order: list[int] = []
-        lc = Lifecycle()
-        lc.on_start(self._hook(order, 1))
-        lc.on_start(self._hook(order, 2))
-        lc.on_start(self._hook(order, 3))
-        await lc.run_start_hooks()
-        assert order == [1, 2, 3]
-
-    async def test_ready_hooks_run_in_order(self) -> None:
-        order: list[int] = []
-        lc = Lifecycle()
-        lc.on_ready(self._hook(order, 10))
-        lc.on_ready(self._hook(order, 20))
-        await lc.run_ready_hooks()
-        assert order == [10, 20]
-
-    async def test_stop_hooks_run_in_reverse(self) -> None:
-        order: list[int] = []
-        lc = Lifecycle()
-        lc.on_stop(self._hook(order, 1))
-        lc.on_stop(self._hook(order, 2))
-        lc.on_stop(self._hook(order, 3))
-        await lc.run_stop_hooks()
-        assert order == [3, 2, 1]
-
-    async def test_configure_hooks_run_in_order(self) -> None:
-        order: list[int] = []
-        lc = Lifecycle()
-        lc.on_configure(self._hook(order, 1))
-        lc.on_configure(self._hook(order, 2))
-        lc.on_configure(self._hook(order, 3))
-        await lc.run_configure_hooks()
-        assert order == [1, 2, 3]
-
-    async def test_no_hooks_is_noop(self) -> None:
-        lc = Lifecycle()
-        await lc.run_configure_hooks()
-        await lc.run_start_hooks()
-        await lc.run_ready_hooks()
-        await lc.run_stop_hooks()
-
-    async def test_hook_error_propagates(self) -> None:
-        lc = Lifecycle()
-
-        async def failing() -> None:
-            raise RuntimeError("boom")
-
-        lc.on_start(failing)
-        with pytest.raises(RuntimeError, match="boom"):
-            await lc.run_start_hooks()
-
-    # helper
-    @staticmethod
-    def _hook(order: list[int], value: int) -> Hook:
-        async def _h() -> None:
-            order.append(value)
-
-        return _h
-
-
-# ---------------------------------------------------------------------------
-# App — chaining API
-# ---------------------------------------------------------------------------
-
-
-class TestAppChaining:
-    def test_convenience_methods_return_self(self) -> None:
-        app = App(_cfg("svc"))
-        sentinel = AsyncMock()
-        result = (
-            app.on_configure(sentinel)
-            .on_start(sentinel)
-            .on_ready(sentinel)
-            .on_stop(sentinel)
-            .set_ready_check(sentinel)
-        )
-        assert result is app
-
-    def test_with_component_returns_self(self) -> None:
-        app = App(_cfg("svc"))
-        comp = _MockComponent("db")
-        result = app.with_component(comp)
-        assert result is app
-
-
-# ---------------------------------------------------------------------------
-# App.run_task
-# ---------------------------------------------------------------------------
-
-
-class TestRunTask:
-    async def test_task_runs_between_hooks(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        app.on_start(_make_hook(order, "start"))
-        app.on_stop(_make_hook(order, "stop"))
-
-        async def task() -> None:
-            order.append("task")
-
-        await app.run_task(task)
-        assert order == ["start", "task", "stop"]
-
-    async def test_stop_hooks_run_even_if_task_fails(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        app.on_stop(_make_hook(order, "stop"))
-
-        async def failing_task() -> None:
-            raise ValueError("task error")
-
-        with pytest.raises(ValueError, match="task error"):
-            await app.run_task(failing_task)
-
-        assert "stop" in order
-
-    async def test_stop_hooks_run_even_if_start_hook_fails(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-
-        async def bad_start() -> None:
-            raise RuntimeError("start failed")
-
-        app.on_start(bad_start)
-        app.on_stop(_make_hook(order, "stop"))
-
-        with pytest.raises(RuntimeError, match="start failed"):
-            await app.run_task(AsyncMock())
-
-        assert "stop" in order
-
-
-# ---------------------------------------------------------------------------
-# App.run (mocked signal wait)
-# ---------------------------------------------------------------------------
-
-
-class TestRun:
-    async def test_full_lifecycle_order(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        app.on_start(_make_hook(order, "start"))
-        app.on_ready(_make_hook(order, "ready"))
-        app.on_stop(_make_hook(order, "stop"))
-
-        async def ready_check() -> None:
-            order.append("check")
-
-        app.set_ready_check(ready_check)
-
-        with patch.object(app, "_wait_for_signal", new_callable=AsyncMock):
-            await app.run()
-
-        assert order == ["start", "check", "ready", "stop"]
-
-    async def test_ready_check_failure_skips_ready_hooks(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        app.on_start(_make_hook(order, "start"))
-        app.on_ready(_make_hook(order, "ready"))
-        app.on_stop(_make_hook(order, "stop"))
-
-        async def failing_check() -> None:
-            raise RuntimeError("not ready")
-
-        app.set_ready_check(failing_check)
-
-        with (
-            patch.object(app, "_wait_for_signal", new_callable=AsyncMock),
-            pytest.raises(RuntimeError, match="not ready"),
-        ):
-            await app.run()
-
-        assert "start" in order
-        assert "ready" not in order
-        assert "stop" in order
-
-    async def test_no_ready_check_skips_check(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        app.on_start(_make_hook(order, "start"))
-        app.on_ready(_make_hook(order, "ready"))
-        app.on_stop(_make_hook(order, "stop"))
-
-        with patch.object(app, "_wait_for_signal", new_callable=AsyncMock):
-            await app.run()
-
-        assert order == ["start", "ready", "stop"]
-
-
-# ---------------------------------------------------------------------------
-# App — config / lifecycle properties
-# ---------------------------------------------------------------------------
-
-
-class TestAppProperties:
-    def test_config_property(self) -> None:
-        cfg = _cfg("svc", version="2.0")
-        app = App(cfg)
-        assert app.config is cfg
-
-    def test_lifecycle_property(self) -> None:
-        app = App(_cfg("svc"))
-        assert isinstance(app.lifecycle, Lifecycle)
-
-
-# ---------------------------------------------------------------------------
-# App — signal handling & shutdown
-# ---------------------------------------------------------------------------
-
-
-class TestSignalHandling:
-    async def test_wait_for_signal_registers_and_removes_handlers(self) -> None:
-        """Cover _wait_for_signal sets/removes signal handlers."""
-        import signal
-
-        app = App(_cfg("sig-test"))
-
-        async def fire_signal_soon() -> None:
-            await asyncio.sleep(0.01)
-            loop = asyncio.get_running_loop()
-            loop.call_soon(lambda: os.kill(os.getpid(), signal.SIGINT))
-
-        task = asyncio.create_task(fire_signal_soon())
-        await app._wait_for_signal()
-        await task
-
-    async def test_run_registers_signal_and_completes(self) -> None:
-        """Full run() with a real signal delivery — covers the signal path."""
-        import signal
-
-        order: list[str] = []
-        app = App(_cfg("full-sig"))
-        app.on_start(_make_hook(order, "start"))
-        app.on_ready(_make_hook(order, "ready"))
-        app.on_stop(_make_hook(order, "stop"))
-
-        async def send_sigint() -> None:
-            await asyncio.sleep(0.02)
-            os.kill(os.getpid(), signal.SIGINT)
-
-        task = asyncio.create_task(send_sigint())
-        await app.run()
-        await task
-        assert order == ["start", "ready", "stop"]
-
-    async def test_shutdown_timeout(self) -> None:
-        """Cover graceful shutdown timeout path."""
-        app = App(_cfg("timeout-test"), graceful_timeout=0.01)
-
-        async def slow_stop() -> None:
-            await asyncio.sleep(10)
-
-        app.on_stop(slow_stop)
-
-        with patch.object(app, "_wait_for_signal", new_callable=AsyncMock):
-            await app.run()
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_hook(order: list[str], label: str) -> Hook:
-    async def _h() -> None:
-        order.append(label)
-
-    return _h
-
-
-# ---------------------------------------------------------------------------
-# Mock component for integration tests
-# ---------------------------------------------------------------------------
+    def error(self, event: str, /, **kwargs: object) -> None:
+        self.errors.append((event, kwargs))
 
 
 class _MockComponent:
-    """Minimal Component implementation for testing."""
+    """Minimal component implementation for tests."""
 
-    def __init__(self, name: str, *, order: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        *,
+        order: list[str] | None = None,
+        start_error: Exception | None = None,
+        stop_error: Exception | None = None,
+    ) -> None:
         self._name = name
         self._order = order
+        self._start_error = start_error
+        self._stop_error = stop_error
         self._started = False
 
     @property
@@ -428,124 +61,261 @@ class _MockComponent:
         return self._name
 
     async def start(self) -> None:
-        self._started = True
         if self._order is not None:
             self._order.append(f"{self._name}:start")
+        if self._start_error is not None:
+            raise self._start_error
+        self._started = True
 
     async def stop(self) -> None:
-        self._started = False
         if self._order is not None:
             self._order.append(f"{self._name}:stop")
+        if self._stop_error is not None:
+            raise self._stop_error
+        self._started = False
 
     async def health(self) -> Health:
         status = HealthStatus.HEALTHY if self._started else HealthStatus.UNHEALTHY
         return Health(name=self._name, status=status)
 
 
-# ---------------------------------------------------------------------------
-# App — component integration
-# ---------------------------------------------------------------------------
+def _cfg(name: str = "svc", **kwargs: object) -> DefaultAppConfig:
+    """Create a DefaultAppConfig with top-level convenience overrides."""
+    svc_kwargs: dict[str, object] = {"name": name}
+    top_kwargs: dict[str, object] = {}
+    svc_fields = {"name", "environment", "version", "debug", "logging"}
+    for key, value in kwargs.items():
+        if key in svc_fields:
+            svc_kwargs[key] = value
+        else:
+            top_kwargs[key] = value
+    return DefaultAppConfig(service=ServiceConfig(**svc_kwargs), **top_kwargs)
 
 
-class TestAppComponents:
-    def test_with_component_registers(self) -> None:
+def _make_hook(order: list[str], label: str) -> Hook:
+    async def _hook() -> None:
+        order.append(label)
+
+    return _hook
+
+
+class TestConfigTypes:
+    def test_environment_values(self) -> None:
+        assert Environment.DEVELOPMENT == "development"
+        assert Environment.STAGING == "staging"
+        assert Environment.PRODUCTION == "production"
+
+    def test_logging_config_defaults(self) -> None:
+        cfg = LoggingConfig()
+        assert cfg.level == "INFO"
+        assert cfg.format == "console"
+
+    def test_service_config_defaults(self) -> None:
+        cfg = ServiceConfig()
+        assert cfg.name == ""
+        assert cfg.environment == Environment.DEVELOPMENT
+        assert cfg.version == "0.0.0"
+        assert cfg.debug is False
+
+    def test_default_app_config_protocol(self) -> None:
+        cfg = _cfg("svc", version="1.2.3")
+        assert isinstance(cfg, AppConfig)
+        assert cfg.service_config.name == "svc"
+        assert cfg.version == "1.2.3"
+
+
+class TestLifecycle:
+    async def test_start_hooks_run_in_order(self) -> None:
+        order: list[int] = []
+        lifecycle = Lifecycle()
+        lifecycle.on_start(self._hook(order, 1))
+        lifecycle.on_start(self._hook(order, 2))
+        lifecycle.on_start(self._hook(order, 3))
+
+        await lifecycle.run_start_hooks(app_name="svc")
+
+        assert order == [1, 2, 3]
+
+    async def test_stop_hooks_run_in_reverse_order(self) -> None:
+        order: list[int] = []
+        lifecycle = Lifecycle()
+        lifecycle.on_stop(self._hook(order, 1))
+        lifecycle.on_stop(self._hook(order, 2))
+        lifecycle.on_stop(self._hook(order, 3))
+
+        await lifecycle.run_stop_hooks(app_name="svc")
+
+        assert order == [3, 2, 1]
+
+    async def test_context_and_event_are_forwarded(self) -> None:
+        seen: list[tuple[dict[str, object] | None, LifecycleEvent]] = []
+        lifecycle = Lifecycle()
+
+        async def handler(context: dict[str, object] | None, event: LifecycleEvent) -> None:
+            seen.append((context, event))
+
+        lifecycle.on_ready(handler)
+        await lifecycle.run_ready_hooks(app_name="svc", context={"phase": "ready"})
+
+        context, event = seen[0]
+        assert context == {"phase": "ready"}
+        assert event.type == EVENT_READY
+        assert event.app_name == "svc"
+
+    async def test_hook_error_runs_later_handlers_and_raises(self) -> None:
+        order: list[str] = []
+        lifecycle = Lifecycle()
+
+        async def failing() -> None:
+            order.append("failing")
+            raise RuntimeError("boom")
+
+        lifecycle.on_start(failing)
+        lifecycle.on_start(_make_hook(order, "after"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await lifecycle.run_start_hooks(app_name="svc")
+
+        assert order == ["failing", "after"]
+
+    @staticmethod
+    def _hook(order: list[int], value: int) -> Hook:
+        async def _hook() -> None:
+            order.append(value)
+
+        return _hook
+
+
+class TestAppAPI:
+    def test_chaining_returns_self(self) -> None:
         app = App(_cfg("svc"))
-        comp = _MockComponent("db")
-        app.with_component(comp)
-        assert app.registry.get("db") is comp
+        result = (
+            app.on_configure(AsyncMock())
+            .on_start(AsyncMock())
+            .on_ready(AsyncMock())
+            .on_stop(AsyncMock())
+            .set_ready_check(AsyncMock())
+        )
+        assert result is app
 
-    def test_registry_property(self) -> None:
+    def test_with_component_returns_self(self) -> None:
         app = App(_cfg("svc"))
+        component = _MockComponent("db")
+        assert app.with_component(component) is app
+        assert app.registry.get("db") is component
+
+    def test_properties_expose_config_lifecycle_and_registry(self) -> None:
+        app = App(_cfg("svc"))
+        assert app.config.service_config.name == "svc"
+        assert isinstance(app.lifecycle, Lifecycle)
         assert isinstance(app.registry, Registry)
 
-    async def test_components_start_before_hooks(self) -> None:
+
+class TestRunTask:
+    async def test_run_task_orders_configure_start_task_stop(self) -> None:
         order: list[str] = []
-        app = App(_cfg("test"))
+        app = App(_cfg("svc"))
         app.with_component(_MockComponent("db", order=order))
         app.on_configure(_make_hook(order, "configure"))
-        app.on_start(_make_hook(order, "start"))
-        app.on_stop(_make_hook(order, "stop"))
+        app.on_start(_make_hook(order, "on_start"))
+        app.on_stop(_make_hook(order, "on_stop"))
 
         async def task() -> None:
             order.append("task")
 
         await app.run_task(task)
-        assert order == ["db:start", "configure", "start", "task", "stop", "db:stop"]
 
-    async def test_full_lifecycle_with_components(self) -> None:
+        assert order == ["configure", "db:start", "on_start", "task", "on_stop", "db:stop"]
+
+    async def test_run_task_start_hook_failure_still_runs_stop_hooks(self) -> None:
         order: list[str] = []
-        app = App(_cfg("test"))
+        app = App(_cfg("svc"))
         app.with_component(_MockComponent("db", order=order))
-        app.on_configure(_make_hook(order, "configure"))
-        app.on_start(_make_hook(order, "start"))
-        app.on_ready(_make_hook(order, "ready"))
-        app.on_stop(_make_hook(order, "stop"))
-
-        with patch.object(app, "_wait_for_signal", new_callable=AsyncMock):
-            await app.run()
-
-        assert order == ["db:start", "configure", "start", "ready", "stop", "db:stop"]
-
-    async def test_components_stop_even_on_hook_failure(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        app.with_component(_MockComponent("db", order=order))
+        app.on_stop(_make_hook(order, "on_stop"))
 
         async def bad_start() -> None:
-            raise RuntimeError("hook failed")
+            order.append("on_start")
+            raise RuntimeError("start failed")
 
         app.on_start(bad_start)
 
-        with pytest.raises(RuntimeError, match="hook failed"):
+        with pytest.raises(RuntimeError, match="start failed"):
             await app.run_task(AsyncMock())
 
-        assert "db:start" in order
-        assert "db:stop" in order
+        assert order == ["db:start", "on_start", "on_stop", "db:stop"]
 
-    async def test_components_stop_in_reverse_order(self) -> None:
+    async def test_logger_can_be_injected(self) -> None:
+        logger = _LoggerStub([], [])
+        app = App(_cfg("svc"), logger=logger)
+
+        await app.run_task(AsyncMock())
+
+        assert any(event == "Starting application" for event, _ in logger.infos)
+        assert any(event == "Shutting down" for event, _ in logger.infos)
+
+
+class TestRun:
+    async def test_full_lifecycle_order_matches_bootstrap_contract(self) -> None:
         order: list[str] = []
-        app = App(_cfg("test"))
+        app = App(_cfg("svc"))
         app.with_component(_MockComponent("db", order=order))
-        app.with_component(_MockComponent("cache", order=order))
+        app.on_configure(_make_hook(order, "configure"))
+        app.on_start(_make_hook(order, "on_start"))
+        app.on_ready(_make_hook(order, "on_ready"))
+        app.on_stop(_make_hook(order, "on_stop"))
 
-        async def task() -> None:
-            pass
+        async def ready_check() -> None:
+            order.append("ready_check")
 
-        await app.run_task(task)
-        assert order == ["db:start", "cache:start", "cache:stop", "db:stop"]
-
-    async def test_shutdown_stops_components_after_timeout(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("timeout-test"), graceful_timeout=0.01)
-        app.with_component(_MockComponent("db", order=order))
-
-        async def slow_stop() -> None:
-            await asyncio.sleep(10)
-
-        app.on_stop(slow_stop)
+        app.set_ready_check(ready_check)
 
         with patch.object(app, "_wait_for_signal", new_callable=AsyncMock):
             await app.run()
 
-        # Components should still be stopped even after hook timeout
-        assert "db:start" in order
-        assert "db:stop" in order
+        assert order == [
+            "configure",
+            "db:start",
+            "on_start",
+            "ready_check",
+            "on_ready",
+            "on_stop",
+            "db:stop",
+        ]
 
+    async def test_lifecycle_events_use_public_event_types(self) -> None:
+        events: list[str] = []
+        app = App(_cfg("svc"))
 
-# ---------------------------------------------------------------------------
-# Re-exports
-# ---------------------------------------------------------------------------
+        async def on_start(event: LifecycleEvent) -> None:
+            events.append(event.type)
+
+        async def on_ready(event: LifecycleEvent) -> None:
+            events.append(event.type)
+
+        async def on_stop(event: LifecycleEvent) -> None:
+            events.append(event.type)
+
+        app.on_start(on_start)
+        app.on_ready(on_ready)
+        app.on_stop(on_stop)
+
+        with patch.object(app, "_wait_for_signal", new_callable=AsyncMock):
+            await app.run()
+
+        assert events == [EVENT_START, EVENT_READY, EVENT_STOP]
 
 
 class TestReExports:
     def test_component_reexported(self) -> None:
         assert Component is not None
 
-    def test_health_reexported(self) -> None:
-        assert Health is not None
-
-    def test_health_status_reexported(self) -> None:
-        assert HealthStatus is not None
-
     def test_registry_reexported(self) -> None:
         assert Registry is not None
+
+    def test_lifecycle_event_reexported(self) -> None:
+        assert LifecycleEvent(type=EVENT_START, app_name="svc") is not None
+
+    def test_health_types_reexported(self) -> None:
+        assert Health is not None
+        assert HealthStatus is not None
+        assert EVENT_STOP == "lifecycle.stop"

--- a/packages/pykit-bootstrap/tests/test_bootstrap_extended.py
+++ b/packages/pykit-bootstrap/tests/test_bootstrap_extended.py
@@ -1,52 +1,27 @@
-"""Extended tests for pykit-bootstrap — covering edge cases and gap areas."""
+"""Extended tests for pykit-bootstrap."""
 
 from __future__ import annotations
 
 import asyncio
+import os
+import signal
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from pykit_bootstrap import (
     App,
-    AppConfig,
     DefaultAppConfig,
-    Environment,
     Health,
     HealthStatus,
     Lifecycle,
-    LoggingConfig,
+    LifecycleEvent,
     ServiceConfig,
 )
-from pykit_component import Registry
-
-# ---------------------------------------------------------------------------
-# Helper — shortcut for creating DefaultAppConfig
-# ---------------------------------------------------------------------------
-
-
-def _cfg(name: str = "svc", **kwargs: object) -> DefaultAppConfig:
-    """Create a DefaultAppConfig with the given service name and optional overrides."""
-    svc_kwargs: dict[str, object] = {"name": name}
-    top_kwargs: dict[str, object] = {}
-    svc_fields = {"name", "environment", "version", "debug", "logging"}
-    for k, v in kwargs.items():
-        if k in svc_fields:
-            svc_kwargs[k] = v
-        else:
-            top_kwargs[k] = v
-    return DefaultAppConfig(service=ServiceConfig(**svc_kwargs), **top_kwargs)
-
-
-def _make_hook(order: list[str], label: str):
-    async def _h() -> None:
-        order.append(label)
-
-    return _h
 
 
 class _MockComponent:
-    """Minimal Component implementation for testing."""
+    """Minimal component implementation for tests."""
 
     def __init__(
         self,
@@ -59,10 +34,10 @@ class _MockComponent:
     ) -> None:
         self._name = name
         self._order = order
-        self._started = False
         self._start_error = start_error
         self._stop_error = stop_error
         self._health_status = health_status
+        self._started = False
 
     @property
     def name(self) -> str:
@@ -71,14 +46,14 @@ class _MockComponent:
     async def start(self) -> None:
         if self._order is not None:
             self._order.append(f"{self._name}:start")
-        if self._start_error:
+        if self._start_error is not None:
             raise self._start_error
         self._started = True
 
     async def stop(self) -> None:
         if self._order is not None:
             self._order.append(f"{self._name}:stop")
-        if self._stop_error:
+        if self._stop_error is not None:
             raise self._stop_error
         self._started = False
 
@@ -87,116 +62,61 @@ class _MockComponent:
         return Health(name=self._name, status=status)
 
 
-# ---------------------------------------------------------------------------
-# 1. Async hook cancellation (CancelledError)
-# ---------------------------------------------------------------------------
+def _cfg(name: str = "svc", **kwargs: object) -> DefaultAppConfig:
+    svc_kwargs: dict[str, object] = {"name": name}
+    top_kwargs: dict[str, object] = {}
+    svc_fields = {"name", "environment", "version", "debug", "logging"}
+    for key, value in kwargs.items():
+        if key in svc_fields:
+            svc_kwargs[key] = value
+        else:
+            top_kwargs[key] = value
+    return DefaultAppConfig(service=ServiceConfig(**svc_kwargs), **top_kwargs)
 
 
-class TestAsyncHookCancellation:
-    async def test_cancelled_start_hook_propagates(self) -> None:
-        lc = Lifecycle()
+def _make_hook(order: list[str], label: str):
+    async def _hook() -> None:
+        order.append(label)
 
-        async def cancelling_hook() -> None:
-            raise asyncio.CancelledError()
-
-        lc.on_start(cancelling_hook)
-        with pytest.raises(asyncio.CancelledError):
-            await lc.run_start_hooks()
-
-    async def test_cancelled_configure_hook_propagates(self) -> None:
-        lc = Lifecycle()
-
-        async def cancelling_hook() -> None:
-            raise asyncio.CancelledError()
-
-        lc.on_configure(cancelling_hook)
-        with pytest.raises(asyncio.CancelledError):
-            await lc.run_configure_hooks()
-
-    async def test_cancelled_stop_hook_propagates(self) -> None:
-        lc = Lifecycle()
-
-        async def cancelling_hook() -> None:
-            raise asyncio.CancelledError()
-
-        lc.on_stop(cancelling_hook)
-        with pytest.raises(asyncio.CancelledError):
-            await lc.run_stop_hooks()
+    return _hook
 
 
-# ---------------------------------------------------------------------------
-# 2. Concurrent hook failures in run_stop_hooks (error aggregation)
-# ---------------------------------------------------------------------------
-
-
-class TestStopHookErrors:
-    async def test_first_stop_hook_error_propagates(self) -> None:
-        """Stop hooks run sequentially (reversed), first error propagates."""
-        lc = Lifecycle()
+class TestStartupFailures:
+    async def test_component_start_failure_emits_stop_hooks(self) -> None:
         order: list[str] = []
-
-        async def hook_a() -> None:
-            order.append("a")
-
-        async def hook_b() -> None:
-            order.append("b")
-            raise RuntimeError("b failed")
-
-        # Registration order: a, b → stop order: b, a
-        lc.on_stop(hook_a)
-        lc.on_stop(hook_b)
-
-        with pytest.raises(RuntimeError, match="b failed"):
-            await lc.run_stop_hooks()
-
-        # b runs first (reversed), fails, a never runs
-        assert order == ["b"]
-
-    async def test_stop_hook_error_does_not_prevent_component_stop(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
+        app = App(_cfg("svc"))
+        app.on_configure(_make_hook(order, "configure"))
+        app.on_stop(_make_hook(order, "on_stop"))
         app.with_component(_MockComponent("db", order=order))
+        app.with_component(_MockComponent("cache", order=order, start_error=RuntimeError("cache boom")))
 
-        async def failing_stop() -> None:
-            raise RuntimeError("hook error")
+        with pytest.raises(RuntimeError, match="cache boom"):
+            await app.run_task(AsyncMock())
 
-        app.on_stop(failing_stop)
+        assert order == ["configure", "db:start", "cache:start", "db:stop", "on_stop"]
+
+    async def test_ready_check_failure_runs_stop_hooks_before_components_stop(self) -> None:
+        order: list[str] = []
+        app = App(_cfg("svc"))
+        app.with_component(_MockComponent("db", order=order))
+        app.on_stop(_make_hook(order, "on_stop"))
+
+        async def failing_ready_check() -> None:
+            order.append("ready_check")
+            raise RuntimeError("not ready")
+
+        app.set_ready_check(failing_ready_check)
 
         with (
             patch.object(app, "_wait_for_signal", new_callable=AsyncMock),
-            pytest.raises(RuntimeError, match="hook error"),
+            pytest.raises(RuntimeError, match="not ready"),
         ):
             await app.run()
 
-        # Components should still stop (via finally) even after hook error
-        assert "db:start" in order
-        assert "db:stop" in order
+        assert order == ["db:start", "ready_check", "on_stop", "db:stop"]
 
-
-# ---------------------------------------------------------------------------
-# 3. RunTask with exception + graceful shutdown race
-# ---------------------------------------------------------------------------
-
-
-class TestRunTaskExceptionShutdown:
-    async def test_task_exception_triggers_shutdown(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        app.with_component(_MockComponent("db", order=order))
-        app.on_stop(_make_hook(order, "stop"))
-
-        async def failing_task() -> None:
-            raise ValueError("task boom")
-
-        with pytest.raises(ValueError, match="task boom"):
-            await app.run_task(failing_task)
-
-        assert "stop" in order
-        assert "db:stop" in order
-
-    async def test_task_exception_with_stop_hook_error(self) -> None:
-        """When both task and stop hook fail, task exception wins."""
-        app = App(_cfg("test"), graceful_timeout=0.01)
+    async def test_task_exception_wins_over_shutdown_timeout(self) -> None:
+        app = App(_cfg("svc"), graceful_timeout=0.01)
 
         async def slow_stop() -> None:
             await asyncio.sleep(10)
@@ -204,323 +124,68 @@ class TestRunTaskExceptionShutdown:
         app.on_stop(slow_stop)
 
         async def failing_task() -> None:
-            raise ValueError("task error")
+            raise ValueError("task boom")
 
-        # The task error should propagate; stop hook times out
-        with pytest.raises(ValueError, match="task error"):
+        with pytest.raises(ValueError, match="task boom"):
             await app.run_task(failing_task)
 
 
-# ---------------------------------------------------------------------------
-# 4. Ready check timeout
-# ---------------------------------------------------------------------------
-
-
-class TestReadyCheckTimeout:
-    async def test_slow_ready_check_blocks_startup(self) -> None:
-        """Ready check that takes too long should propagate naturally."""
-        app = App(_cfg("test"))
-
-        async def slow_check() -> None:
-            await asyncio.sleep(0.05)
-
-        app.set_ready_check(slow_check)
-
-        with patch.object(app, "_wait_for_signal", new_callable=AsyncMock):
-            # Should still complete — just slowly
-            await app.run()
-
-    async def test_failing_ready_check_propagates(self) -> None:
-        app = App(_cfg("test"))
-
-        async def failing_check() -> None:
-            raise RuntimeError("health check failed")
-
-        app.set_ready_check(failing_check)
+class TestHookHandling:
+    async def test_stop_hook_error_does_not_prevent_component_stop(self) -> None:
         order: list[str] = []
-        app.on_stop(_make_hook(order, "stop"))
+        app = App(_cfg("svc"))
+        app.with_component(_MockComponent("db", order=order))
+
+        async def failing_stop() -> None:
+            order.append("failing_stop")
+            raise RuntimeError("stop hook failed")
+
+        app.on_stop(failing_stop)
+        app.on_stop(_make_hook(order, "after_stop"))
 
         with (
             patch.object(app, "_wait_for_signal", new_callable=AsyncMock),
-            pytest.raises(RuntimeError, match="health check failed"),
+            pytest.raises(RuntimeError, match="stop hook failed"),
         ):
             await app.run()
 
-        # Stop hooks should still run via finally
-        assert "stop" in order
+        assert order == ["db:start", "after_stop", "failing_stop", "db:stop"]
 
+    async def test_lifecycle_context_handlers_receive_app_context(self) -> None:
+        seen: list[tuple[dict[str, object] | None, LifecycleEvent]] = []
+        app = App(_cfg("svc"))
 
-# ---------------------------------------------------------------------------
-# 5. Logging setup with invalid/edge-case log level
-# ---------------------------------------------------------------------------
+        async def on_start(context: dict[str, object] | None, event: LifecycleEvent) -> None:
+            seen.append((context, event))
 
-
-class TestLoggingSetup:
-    async def test_debug_mode_overrides_log_level(self) -> None:
-        cfg = _cfg("svc", debug=True, logging=LoggingConfig(level="ERROR", format="json"))
-        app = App(cfg)
-
-        # Should not raise even though debug overrides log level
+        app.on_start(on_start)
         await app.run_task(AsyncMock())
 
-    async def test_production_logging_config(self) -> None:
-        cfg = _cfg(
-            "prod-svc",
-            environment=Environment.PRODUCTION,
-            logging=LoggingConfig(level="WARNING", format="json"),
-        )
-        app = App(cfg)
-        await app.run_task(AsyncMock())
+        context, event = seen[0]
+        assert context is not None
+        assert context["app"] is app
+        assert context["registry"] is app.registry
+        assert event.app_name == "svc"
 
+    async def test_lifecycle_preserves_cancelled_error(self) -> None:
+        lifecycle = Lifecycle()
 
-# ---------------------------------------------------------------------------
-# 6. Multiple on_configure hooks with dependency order
-# ---------------------------------------------------------------------------
+        async def cancelling() -> None:
+            raise asyncio.CancelledError()
 
+        lifecycle.on_start(cancelling)
+        with pytest.raises(asyncio.CancelledError):
+            await lifecycle.run_start_hooks(app_name="svc")
 
-class TestMultipleConfigureHooks:
-    async def test_configure_hooks_execute_in_registration_order(self) -> None:
-        order: list[int] = []
-        lc = Lifecycle()
-        for i in range(5):
-            val = i
 
-            async def hook(v: int = val) -> None:
-                order.append(v)
+class TestSignalHandling:
+    async def test_wait_for_signal_registers_and_removes_handlers(self) -> None:
+        app = App(_cfg("sig"))
 
-            lc.on_configure(hook)
+        async def fire_signal() -> None:
+            await asyncio.sleep(0.01)
+            os.kill(os.getpid(), signal.SIGINT)
 
-        await lc.run_configure_hooks()
-        assert order == [0, 1, 2, 3, 4]
-
-    async def test_configure_hook_can_depend_on_previous(self) -> None:
-        """Second configure hook can use state set by the first."""
-        state: dict[str, str] = {}
-        app = App(_cfg("test"))
-
-        async def set_db() -> None:
-            state["db"] = "postgres://localhost"
-
-        async def set_cache() -> None:
-            assert "db" in state, "cache hook depends on db hook"
-            state["cache"] = "redis://localhost"
-
-        app.on_configure(set_db)
-        app.on_configure(set_cache)
-
-        await app.run_task(AsyncMock())
-        assert state == {"db": "postgres://localhost", "cache": "redis://localhost"}
-
-
-# ---------------------------------------------------------------------------
-# 7. Config protocol methods called in wrong order
-# ---------------------------------------------------------------------------
-
-
-class TestConfigProtocol:
-    def test_default_app_config_satisfies_protocol(self) -> None:
-        cfg = _cfg("test")
-        assert isinstance(cfg, AppConfig)
-
-    def test_apply_defaults_before_service_config(self) -> None:
-        cfg = DefaultAppConfig()
-        # Before apply_defaults, name is empty
-        assert cfg.service.name == ""
-        cfg.apply_defaults()
-        assert cfg.service.name == "unknown"
-        # service_config should reflect the updated value
-        assert cfg.service_config.name == "unknown"
-
-    def test_custom_config_satisfies_protocol(self) -> None:
-        """Custom class implementing AppConfig protocol."""
-
-        class CustomConfig:
-            def apply_defaults(self) -> None:
-                pass
-
-            @property
-            def service_config(self) -> ServiceConfig:
-                return ServiceConfig(name="custom")
-
-        cfg = CustomConfig()
-        assert isinstance(cfg, AppConfig)
-        assert cfg.service_config.name == "custom"
-
-
-# ---------------------------------------------------------------------------
-# 8. Component registry failing during startup (partial component stop)
-# ---------------------------------------------------------------------------
-
-
-class TestPartialComponentStartup:
-    async def test_partial_start_failure_still_stops_started_components(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-
-        app.with_component(_MockComponent("db", order=order))
-        app.with_component(_MockComponent("cache", order=order, start_error=RuntimeError("cache fail")))
-        app.with_component(_MockComponent("kafka", order=order))
-
-        with pytest.raises(RuntimeError, match="cache fail"):
-            await app.run_task(AsyncMock())
-
-        assert "db:start" in order
-        assert "cache:start" in order
-        # kafka should NOT have started
-        assert "kafka:start" not in order
-        # db and cache should be stopped (via finally in _shutdown)
-        assert "db:stop" in order
-
-    async def test_component_start_order_is_registration_order(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        for name in ["alpha", "beta", "gamma"]:
-            app.with_component(_MockComponent(name, order=order))
-
-        await app.run_task(AsyncMock())
-        starts = [e for e in order if e.endswith(":start")]
-        assert starts == ["alpha:start", "beta:start", "gamma:start"]
-
-    async def test_component_stop_order_is_reverse_registration(self) -> None:
-        order: list[str] = []
-        app = App(_cfg("test"))
-        for name in ["alpha", "beta", "gamma"]:
-            app.with_component(_MockComponent(name, order=order))
-
-        await app.run_task(AsyncMock())
-        stops = [e for e in order if e.endswith(":stop")]
-        assert stops == ["gamma:stop", "beta:stop", "alpha:stop"]
-
-
-# ---------------------------------------------------------------------------
-# 9. Fluent API chaining verification (returns self)
-# ---------------------------------------------------------------------------
-
-
-class TestFluentAPI:
-    def test_with_component_chaining(self) -> None:
-        app = App(_cfg("svc"))
-        result = (
-            app.with_component(_MockComponent("a"))
-            .with_component(_MockComponent("b"))
-            .with_component(_MockComponent("c"))
-        )
-        assert result is app
-
-    def test_hook_chaining(self) -> None:
-        app = App(_cfg("svc"))
-        sentinel = AsyncMock()
-        result = app.on_configure(sentinel).on_start(sentinel).on_ready(sentinel).on_stop(sentinel)
-        assert result is app
-
-    def test_set_ready_check_chaining(self) -> None:
-        app = App(_cfg("svc"))
-        result = app.set_ready_check(AsyncMock())
-        assert result is app
-
-    def test_mixed_chaining(self) -> None:
-        app = App(_cfg("svc"))
-        result = (
-            app.with_component(_MockComponent("db"))
-            .on_configure(AsyncMock())
-            .on_start(AsyncMock())
-            .with_component(_MockComponent("cache"))
-            .on_stop(AsyncMock())
-            .set_ready_check(AsyncMock())
-        )
-        assert result is app
-
-
-# ---------------------------------------------------------------------------
-# 10. Empty app (no components, no hooks) run_task
-# ---------------------------------------------------------------------------
-
-
-class TestEmptyApp:
-    async def test_empty_app_run_task(self) -> None:
-        app = App(_cfg("empty"))
-
-        async def task() -> None:
-            pass
-
-        # Should complete without error
-        await app.run_task(task)
-
-    async def test_empty_app_run(self) -> None:
-        app = App(_cfg("empty"))
-
-        with patch.object(app, "_wait_for_signal", new_callable=AsyncMock):
-            await app.run()
-
-    async def test_empty_lifecycle_hooks_are_noop(self) -> None:
-        lc = Lifecycle()
-        # All should complete without error
-        await lc.run_configure_hooks()
-        await lc.run_start_hooks()
-        await lc.run_ready_hooks()
-        await lc.run_stop_hooks()
-
-
-# ---------------------------------------------------------------------------
-# Additional edge-case tests
-# ---------------------------------------------------------------------------
-
-
-class TestLifecycleEdgeCases:
-    async def test_hook_exception_type_preserved(self) -> None:
-        """Specific exception types should propagate unchanged."""
-        lc = Lifecycle()
-
-        async def type_error_hook() -> None:
-            raise TypeError("wrong type")
-
-        lc.on_start(type_error_hook)
-        with pytest.raises(TypeError, match="wrong type"):
-            await lc.run_start_hooks()
-
-    async def test_many_hooks_all_run(self) -> None:
-        """Verify a large number of hooks all execute."""
-        count = 0
-        lc = Lifecycle()
-
-        for _ in range(50):
-
-            async def hook() -> None:
-                nonlocal count
-                count += 1
-
-            lc.on_start(hook)
-
-        await lc.run_start_hooks()
-        assert count == 50
-
-    async def test_stop_hooks_reverse_with_single_hook(self) -> None:
-        order: list[str] = []
-        lc = Lifecycle()
-        lc.on_stop(_make_hook(order, "only"))
-        await lc.run_stop_hooks()
-        assert order == ["only"]
-
-
-class TestAppProperties:
-    def test_config_property_returns_config(self) -> None:
-        cfg = _cfg("svc", version="3.0")
-        app = App(cfg)
-        assert app.config is cfg
-        assert app.config.service_config.name == "svc"
-
-    def test_lifecycle_property(self) -> None:
-        app = App(_cfg("svc"))
-        assert isinstance(app.lifecycle, Lifecycle)
-
-    def test_registry_property(self) -> None:
-        app = App(_cfg("svc"))
-        assert isinstance(app.registry, Registry)
-
-    def test_graceful_timeout_custom(self) -> None:
-        app = App(_cfg("svc"), graceful_timeout=5.0)
-        assert app._graceful_timeout == 5.0
-
-    def test_graceful_timeout_default(self) -> None:
-        app = App(_cfg("svc"))
-        assert app._graceful_timeout == 30.0
+        task = asyncio.create_task(fire_signal())
+        await app._wait_for_signal()
+        await task

--- a/packages/pykit-component/src/pykit_component/__init__.py
+++ b/packages/pykit-component/src/pykit_component/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pykit_component.interfaces import Component, Describable, Description, Health, HealthStatus
-from pykit_component.registry import Registry
+from pykit_component.interfaces import Component, Describable, Description, Health, HealthStatus, State
+from pykit_component.registry import Registry, StopResult
 
 __all__ = [
     "Component",
@@ -12,4 +12,6 @@ __all__ = [
     "Health",
     "HealthStatus",
     "Registry",
+    "State",
+    "StopResult",
 ]

--- a/packages/pykit-component/src/pykit_component/interfaces.py
+++ b/packages/pykit-component/src/pykit_component/interfaces.py
@@ -8,6 +8,21 @@ from datetime import UTC, datetime
 from typing import Protocol, runtime_checkable
 
 
+class State(enum.IntEnum):
+    """Lifecycle state for a registered component."""
+
+    CREATED = 0
+    STARTING = 1
+    RUNNING = 2
+    STOPPING = 3
+    STOPPED = 4
+    FAILED = 5
+
+    def __str__(self) -> str:
+        """Return the lowercase state name."""
+        return self.name.lower()
+
+
 class HealthStatus(enum.StrEnum):
     """Health state of a component."""
 

--- a/packages/pykit-component/src/pykit_component/registry.py
+++ b/packages/pykit-component/src/pykit_component/registry.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
-from pykit_component.interfaces import Component, Health
+import asyncio
+import contextlib
+import threading
+from dataclasses import dataclass
+
+from pykit_component.interfaces import Component, Health, State
 
 
+@dataclass(slots=True)
 class _Entry:
-    __slots__ = ("component", "started")
+    component: Component
+    state: State = State.CREATED
 
-    def __init__(self, component: Component) -> None:
-        self.component = component
-        self.started = False
+
+@dataclass(frozen=True)
+class StopResult:
+    """Detailed result for stopping a single component."""
+
+    name: str
+    error: Exception | None
 
 
 class Registry:
@@ -22,57 +33,122 @@ class Registry:
     def __init__(self) -> None:
         self._entries: list[_Entry] = []
         self._lookup: dict[str, _Entry] = {}
+        self._lock = threading.Lock()
+        self._lifecycle_lock = asyncio.Lock()
 
     def register(self, component: Component) -> None:
-        """Add a component. Raises ``ValueError`` on duplicate names."""
+        """Add a component.
+
+        Args:
+            component: Component to register.
+
+        Raises:
+            ValueError: If a component with the same name already exists.
+        """
         name = component.name
-        if name in self._lookup:
-            raise ValueError(f"component '{name}' already registered")
-        entry = _Entry(component)
-        self._entries.append(entry)
-        self._lookup[name] = entry
+        with self._lock:
+            if name in self._lookup:
+                raise ValueError(f"component '{name}' already registered")
+            entry = _Entry(component)
+            self._entries.append(entry)
+            self._lookup[name] = entry
 
     async def start_all(self) -> None:
-        """Start all components in registration order. Rolls back on partial failure."""
-        import contextlib
+        """Start all startable components in registration order.
 
-        started: list[_Entry] = []
-        try:
-            for entry in self._entries:
-                await entry.component.start()
-                entry.started = True
-                started.append(entry)
-        except Exception:
-            for e in reversed(started):
-                with contextlib.suppress(Exception):
-                    await e.component.stop()
-                e.started = False
-            raise
+        Components in ``CREATED``, ``STOPPED``, or ``FAILED`` state are eligible to start.
+        A failure rolls back already-started components in reverse order.
+        """
+        async with self._lifecycle_lock:
+            with self._lock:
+                entries = list(self._entries)
+
+            started: list[_Entry] = []
+            for entry in entries:
+                if entry.state == State.RUNNING:
+                    continue
+                if entry.state not in {State.CREATED, State.STOPPED, State.FAILED}:
+                    continue
+
+                self._set_state(entry, State.STARTING)
+                try:
+                    await entry.component.start()
+                except Exception:
+                    self._set_state(entry, State.FAILED)
+                    await self._rollback_started(started)
+                    raise
+                except BaseException:
+                    self._set_state(entry, State.FAILED)
+                    await self._rollback_started(started)
+                    raise
+                else:
+                    self._set_state(entry, State.RUNNING)
+                    started.append(entry)
 
     async def stop_all(self) -> None:
-        """Stop all started components in reverse registration order."""
-        errors: list[Exception] = []
-        for entry in reversed(self._entries):
-            if not entry.started:
-                continue
-            try:
-                await entry.component.stop()
-            except Exception as exc:
-                errors.append(exc)
-            finally:
-                entry.started = False
+        """Stop all running components in reverse registration order.
+
+        Raises:
+            ExceptionGroup: If one or more components fail to stop.
+        """
+        results = await self.stop_all_detailed()
+        errors = [result.error for result in results if result.error is not None]
         if errors:
             raise ExceptionGroup("shutdown errors", errors)
 
+    async def stop_all_detailed(self) -> list[StopResult]:
+        """Stop all running components and return per-component results."""
+        async with self._lifecycle_lock:
+            with self._lock:
+                entries = [entry for entry in reversed(self._entries) if entry.state == State.RUNNING]
+
+            results: list[StopResult] = []
+            for entry in entries:
+                self._set_state(entry, State.STOPPING)
+                try:
+                    await entry.component.stop()
+                except Exception as exc:
+                    self._set_state(entry, State.FAILED)
+                    results.append(StopResult(name=entry.component.name, error=exc))
+                except BaseException:
+                    self._set_state(entry, State.RUNNING)
+                    raise
+                else:
+                    self._set_state(entry, State.STOPPED)
+                    results.append(StopResult(name=entry.component.name, error=None))
+            return results
+
     async def health_all(self) -> list[Health]:
         """Return health status for every registered component."""
-        return [await entry.component.health() for entry in self._entries]
+        with self._lock:
+            components = [entry.component for entry in self._entries]
+        return [await component.health() for component in components]
 
     def get(self, name: str) -> Component | None:
         """Return a component by name, or ``None``."""
-        entry = self._lookup.get(name)
-        return entry.component if entry else None
+        with self._lock:
+            entry = self._lookup.get(name)
+            return entry.component if entry else None
 
     def all(self) -> list[Component]:
         """Return all components in registration order."""
-        return [entry.component for entry in self._entries]
+        with self._lock:
+            return [entry.component for entry in self._entries]
+
+    def state(self, name: str) -> State | None:
+        """Return the current state for a registered component."""
+        with self._lock:
+            entry = self._lookup.get(name)
+            return entry.state if entry else None
+
+    def _set_state(self, entry: _Entry, state: State) -> None:
+        with self._lock:
+            entry.state = state
+
+    async def _rollback_started(self, started: list[_Entry]) -> None:
+        for entry in reversed(started):
+            self._set_state(entry, State.STOPPING)
+            with contextlib.suppress(Exception):
+                await entry.component.stop()
+            if self.state(entry.component.name) == State.STOPPING:
+                self._set_state(entry, State.STOPPED)

--- a/packages/pykit-component/tests/test_component.py
+++ b/packages/pykit-component/tests/test_component.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from pykit_component import Component, Description, Health, HealthStatus, Registry
+from pykit_component import Component, Description, Health, HealthStatus, Registry, State
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -297,7 +297,7 @@ class TestCancelledError:
         await r.start_all()
         # Replace with a component that cancels on stop
         r._entries[0].component = CancellingComponent("cancel-on-stop")
-        r._entries[0].started = True
+        r._entries[0].state = State.RUNNING
         with pytest.raises(asyncio.CancelledError):
             await r.stop_all()
 

--- a/packages/pykit-component/tests/test_registry_state.py
+++ b/packages/pykit-component/tests/test_registry_state.py
@@ -1,0 +1,129 @@
+"""State-machine tests for the component registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from pykit_component import Health, HealthStatus, Registry, State
+
+
+class StatefulComponent:
+    """Configurable component for lifecycle tests."""
+
+    def __init__(self, name: str, *, fail_starts: int = 0, stop_error: Exception | None = None) -> None:
+        self._name = name
+        self._remaining_fail_starts = fail_starts
+        self._stop_error = stop_error
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        if self._remaining_fail_starts > 0:
+            self._remaining_fail_starts -= 1
+            raise RuntimeError(f"{self._name} start failed")
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        if self._stop_error is not None:
+            raise self._stop_error
+
+    async def health(self) -> Health:
+        return Health(name=self._name, status=HealthStatus.HEALTHY)
+
+
+class TestRegistryState:
+    @pytest.mark.asyncio
+    async def test_start_all_updates_states(self) -> None:
+        registry = Registry()
+        component = StatefulComponent("db")
+        registry.register(component)
+
+        assert registry.state("db") == State.CREATED
+
+        await registry.start_all()
+
+        assert registry.state("db") == State.RUNNING
+        assert str(State.STARTING) == "starting"
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_rolls_back_started_components(self) -> None:
+        registry = Registry()
+        first = StatefulComponent("first")
+        second = StatefulComponent("second", fail_starts=1)
+        third = StatefulComponent("third")
+        registry.register(first)
+        registry.register(second)
+        registry.register(third)
+
+        with pytest.raises(RuntimeError, match="second start failed"):
+            await registry.start_all()
+
+        assert registry.state("first") == State.STOPPED
+        assert registry.state("second") == State.FAILED
+        assert registry.state("third") == State.CREATED
+        assert first.stop_calls == 1
+        assert third.start_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_all_detailed_collects_all_errors(self) -> None:
+        registry = Registry()
+        first = StatefulComponent("first", stop_error=RuntimeError("first stop failed"))
+        second = StatefulComponent("second", stop_error=RuntimeError("second stop failed"))
+        registry.register(first)
+        registry.register(second)
+        await registry.start_all()
+
+        results = await registry.stop_all_detailed()
+
+        assert [result.name for result in results] == ["second", "first"]
+        assert [str(result.error) for result in results if result.error is not None] == [
+            "second stop failed",
+            "first stop failed",
+        ]
+        assert registry.state("first") == State.FAILED
+        assert registry.state("second") == State.FAILED
+
+    @pytest.mark.asyncio
+    async def test_stop_all_raises_exception_group_with_all_errors(self) -> None:
+        registry = Registry()
+        registry.register(StatefulComponent("first", stop_error=RuntimeError("first stop failed")))
+        registry.register(StatefulComponent("second", stop_error=RuntimeError("second stop failed")))
+        await registry.start_all()
+
+        with pytest.raises(ExceptionGroup) as exc_info:
+            await registry.stop_all()
+
+        assert [str(error) for error in exc_info.value.exceptions] == [
+            "second stop failed",
+            "first stop failed",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_restart_from_failed_and_stopped(self) -> None:
+        registry = Registry()
+        flaky = StatefulComponent("flaky", fail_starts=1)
+        stable = StatefulComponent("stable")
+        registry.register(flaky)
+        registry.register(stable)
+
+        with pytest.raises(RuntimeError, match="flaky start failed"):
+            await registry.start_all()
+
+        assert registry.state("flaky") == State.FAILED
+
+        await registry.start_all()
+        assert registry.state("flaky") == State.RUNNING
+        assert registry.state("stable") == State.RUNNING
+
+        await registry.stop_all()
+        assert registry.state("flaky") == State.STOPPED
+        assert registry.state("stable") == State.STOPPED
+
+        await registry.start_all()
+        assert registry.state("flaky") == State.RUNNING
+        assert registry.state("stable") == State.RUNNING

--- a/packages/pykit-di/src/pykit_di/__init__.py
+++ b/packages/pykit-di/src/pykit_di/__init__.py
@@ -1,7 +1,25 @@
-"""pykit_di — Dependency injection container with eager, lazy, and singleton modes."""
+"""pykit_di — Dependency injection container with typed keys."""
 
 from __future__ import annotations
 
-from pykit_di.container import Container, RegistrationMode
+from pykit_di.container import (
+    Container,
+    Key,
+    RegistrationMode,
+    must_resolve_key,
+    provide,
+    provide_singleton,
+    provide_transient,
+    resolve_key,
+)
 
-__all__ = ["Container", "RegistrationMode"]
+__all__ = [
+    "Container",
+    "Key",
+    "RegistrationMode",
+    "must_resolve_key",
+    "provide",
+    "provide_singleton",
+    "provide_transient",
+    "resolve_key",
+]

--- a/packages/pykit-di/src/pykit_di/container.py
+++ b/packages/pykit-di/src/pykit_di/container.py
@@ -1,4 +1,4 @@
-"""Dependency injection container with eager, lazy, and singleton registration modes."""
+"""Dependency injection container with eager, lazy, singleton, and transient modes."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import threading
 import warnings
 from collections.abc import Callable
 from contextvars import ContextVar
-from typing import Any, TypeVar, overload
+from typing import Generic, TypeVar, cast, overload
 
 T = TypeVar("T")
 
@@ -20,6 +20,21 @@ class RegistrationMode(enum.StrEnum):
     EAGER = "eager"
     LAZY = "lazy"
     SINGLETON = "singleton"
+    TRANSIENT = "transient"
+
+
+class Key(Generic[T]):
+    """Typed registration key."""
+
+    __slots__ = ("_name",)
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        """Return the string name used by the container."""
+        return self._name
 
 
 class _Registration:
@@ -27,11 +42,11 @@ class _Registration:
 
     __slots__ = ("factory", "initialized", "instance", "mode", "name")
 
-    def __init__(self, name: str, factory: Callable[[], Any] | None, mode: RegistrationMode) -> None:
+    def __init__(self, name: str, factory: Callable[[], object] | None, mode: RegistrationMode) -> None:
         self.name = name
         self.factory = factory
         self.mode = mode
-        self.instance: Any = None
+        self.instance: object | None = None
         self.initialized = False
 
 
@@ -42,23 +57,16 @@ class CircularDependencyError(Exception):
 class Container:
     """Dependency injection container.
 
-    Supports three registration modes:
+    Supports four registration modes:
     - **EAGER**: factory runs immediately at registration time.
     - **LAZY**: factory runs on first ``resolve()``, result cached.
     - **SINGLETON**: alias for LAZY (deferred, cached).
-
-    Circular dependency detection prevents infinite recursion when
-    a factory calls ``resolve()`` on the same container for a name
-    that is currently being resolved.
+    - **TRANSIENT**: factory runs on every ``resolve()``, result not cached.
     """
 
     def __init__(self) -> None:
         self._registrations: dict[str, _Registration] = {}
         self._lock = threading.Lock()
-
-    # ------------------------------------------------------------------
-    # ContextVar-based cycle detection helpers
-    # ------------------------------------------------------------------
 
     @staticmethod
     def _get_resolving() -> frozenset[str]:
@@ -74,14 +82,10 @@ class Container:
         current = _resolving_var.get()
         _resolving_var.set(current - {name})
 
-    # ------------------------------------------------------------------
-    # Registration
-    # ------------------------------------------------------------------
-
     def register(
         self,
         name: str,
-        factory: Callable[[], Any],
+        factory: Callable[[], object],
         mode: RegistrationMode = RegistrationMode.EAGER,
     ) -> None:
         """Register a factory under *name* with the given *mode*."""
@@ -92,7 +96,7 @@ class Container:
                 reg.initialized = True
             self._registrations[name] = reg
 
-    def register_instance(self, name: str, instance: Any) -> None:
+    def register_instance(self, name: str, instance: object) -> None:
         """Register a pre-built *instance* (singleton shorthand)."""
         with self._lock:
             reg = _Registration(name, None, RegistrationMode.SINGLETON)
@@ -100,39 +104,29 @@ class Container:
             reg.initialized = True
             self._registrations[name] = reg
 
-    def register_lazy(self, name: str, factory: Callable[[], Any]) -> None:
+    def register_lazy(self, name: str, factory: Callable[[], object]) -> None:
         """Shorthand for ``register(name, factory, RegistrationMode.LAZY)``."""
         self.register(name, factory, RegistrationMode.LAZY)
 
-    def register_singleton(self, name: str, factory: Callable[[], Any]) -> None:
+    def register_singleton(self, name: str, factory: Callable[[], object]) -> None:
         """Shorthand for ``register(name, factory, RegistrationMode.SINGLETON)``."""
         self.register(name, factory, RegistrationMode.SINGLETON)
 
-    # ------------------------------------------------------------------
-    # Resolution
-    # ------------------------------------------------------------------
+    def register_transient(self, name: str, factory: Callable[[], object]) -> None:
+        """Shorthand for ``register(name, factory, RegistrationMode.TRANSIENT)``."""
+        self.register(name, factory, RegistrationMode.TRANSIENT)
 
     @overload
     def resolve(self, name: str, type_hint: type[T]) -> T: ...
 
     @overload
-    def resolve(self, name: str, type_hint: None = ...) -> Any: ...
+    def resolve(self, name: str, type_hint: None = ...) -> object: ...
 
-    def resolve(self, name: str, type_hint: type[T] | None = None) -> T | Any:
-        """Resolve a component by *name*.
-
-        If *type_hint* is provided the resolved value is checked with
-        ``isinstance`` and a ``TypeError`` is raised on mismatch.
-
-        Prefer passing an explicit ``type_hint`` for full type safety.
-        Calling without ``type_hint`` returns ``Any`` and is deprecated.
-
-        Raises ``KeyError`` if *name* is not registered.
-        Raises ``CircularDependencyError`` on re-entrant resolution.
-        """
+    def resolve(self, name: str, type_hint: type[T] | None = None) -> T | object:
+        """Resolve a component by *name*."""
         if type_hint is None:
             warnings.warn(
-                "resolve() without type_hint returns Any and is deprecated. "
+                "resolve() without type_hint returns object and is deprecated. "
                 "Pass an explicit type: container.resolve(name, MyService)",
                 DeprecationWarning,
                 stacklevel=2,
@@ -145,21 +139,20 @@ class Container:
             if reg.initialized:
                 return self._check_type(name, reg.instance, type_hint)
 
-            # Circular dependency guard
             if name in self._get_resolving():
                 raise CircularDependencyError(f"Circular dependency detected while resolving '{name}'")
             self._enter_resolving(name)
 
-        # Factory call outside lock to avoid deadlock, but guard is set.
         try:
             assert reg.factory is not None
             instance = reg.factory()
         finally:
             self._exit_resolving(name)
 
-        with self._lock:
-            reg.instance = instance
-            reg.initialized = True
+        if reg.mode != RegistrationMode.TRANSIENT:
+            with self._lock:
+                reg.instance = instance
+                reg.initialized = True
 
         return self._check_type(name, instance, type_hint)
 
@@ -167,23 +160,19 @@ class Container:
     def resolve_all(self, type_hint: type[T]) -> list[T]: ...
 
     @overload
-    def resolve_all(self, type_hint: None = ...) -> list[Any]: ...
+    def resolve_all(self, type_hint: None = ...) -> list[object]: ...
 
-    def resolve_all(self, type_hint: type[T] | None = None) -> list[T] | list[Any]:
-        """Resolve **all** registered components, optionally filtered by *type_hint*."""
-        results: list[Any] = []
+    def resolve_all(self, type_hint: type[T] | None = None) -> list[T] | list[object]:
+        """Resolve all registered components, optionally filtered by type."""
+        results: list[object] = []
         with self._lock:
             names = list(self._registrations)
 
         for name in names:
-            instance = self.resolve(name)
+            instance = self.resolve(name, object)
             if type_hint is None or isinstance(instance, type_hint):
                 results.append(instance)
-        return results
-
-    # ------------------------------------------------------------------
-    # Introspection
-    # ------------------------------------------------------------------
+        return cast("list[T] | list[object]", results)
 
     def has(self, name: str) -> bool:
         """Return ``True`` if *name* is registered."""
@@ -195,21 +184,42 @@ class Container:
         with self._lock:
             return list(self._registrations)
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
     def clear(self) -> None:
         """Remove all registrations and reset internal state."""
         with self._lock:
             self._registrations.clear()
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
     @staticmethod
-    def _check_type(name: str, instance: Any, type_hint: type[T] | None) -> T | Any:
+    def _check_type(name: str, instance: object, type_hint: type[T] | None) -> T | object:
         if type_hint is not None and not isinstance(instance, type_hint):
             raise TypeError(f"Component '{name}' is {type(instance).__name__}, expected {type_hint.__name__}")
         return instance
+
+
+def provide(container: Container, key: Key[T], factory: Callable[..., T]) -> None:
+    """Register a typed lazy factory."""
+    container.register_lazy(key.name, cast("Callable[[], object]", factory))
+
+
+def provide_singleton(container: Container, key: Key[T], instance: T) -> None:
+    """Register a typed singleton instance."""
+    container.register_instance(key.name, instance)
+
+
+def provide_transient(container: Container, key: Key[T], factory: Callable[..., T]) -> None:
+    """Register a typed transient factory."""
+    container.register(
+        key.name,
+        cast("Callable[[], object]", factory),
+        RegistrationMode.TRANSIENT,
+    )
+
+
+def resolve_key(container: Container, key: Key[T]) -> T:
+    """Resolve a typed key."""
+    return cast("T", container.resolve(key.name, object))
+
+
+def must_resolve_key(container: Container, key: Key[T]) -> T:
+    """Resolve a typed key or raise the underlying container error."""
+    return resolve_key(container, key)

--- a/packages/pykit-di/tests/test_di.py
+++ b/packages/pykit-di/tests/test_di.py
@@ -296,6 +296,7 @@ class TestRegistrationMode:
         assert RegistrationMode.EAGER == "eager"
         assert RegistrationMode.LAZY == "lazy"
         assert RegistrationMode.SINGLETON == "singleton"
+        assert RegistrationMode.TRANSIENT == "transient"
 
     def test_is_str(self) -> None:
         assert isinstance(RegistrationMode.EAGER, str)

--- a/packages/pykit-di/tests/test_di_extended.py
+++ b/packages/pykit-di/tests/test_di_extended.py
@@ -730,7 +730,7 @@ class TestRegistrationModeExtended:
             assert isinstance(mode, str)
 
     def test_mode_count(self) -> None:
-        assert len(RegistrationMode) == 3
+        assert len(RegistrationMode) == 4
 
     def test_modes_distinct(self) -> None:
         modes = [m.value for m in RegistrationMode]

--- a/packages/pykit-di/tests/test_typed_keys.py
+++ b/packages/pykit-di/tests/test_typed_keys.py
@@ -1,0 +1,55 @@
+"""Typed-key tests for the DI container."""
+
+from __future__ import annotations
+
+import pytest
+
+from pykit_di import (
+    Container,
+    Key,
+    RegistrationMode,
+    must_resolve_key,
+    provide,
+    provide_singleton,
+    provide_transient,
+    resolve_key,
+)
+from pykit_di.container import CircularDependencyError
+
+
+class TestTypedKeys:
+    def test_typed_lazy_and_singleton_apis(self) -> None:
+        container = Container()
+        lazy_key = Key[str]("lazy")
+        singleton_key = Key[int]("singleton")
+
+        provide(container, lazy_key, lambda: "value")
+        provide_singleton(container, singleton_key, 42)
+
+        assert resolve_key(container, lazy_key) == "value"
+        assert must_resolve_key(container, singleton_key) == 42
+
+    def test_transient_returns_new_instance_each_time(self) -> None:
+        container = Container()
+        key = Key[list[str]]("transient")
+
+        provide_transient(container, key, list)
+
+        first = resolve_key(container, key)
+        second = resolve_key(container, key)
+
+        assert first == []
+        assert second == []
+        assert first is not second
+        assert RegistrationMode.TRANSIENT == "transient"
+
+    def test_typed_key_circular_detection(self) -> None:
+        container = Container()
+        first = Key[str]("first")
+        second = Key[str]("second")
+
+        provide(container, first, lambda: resolve_key(container, second))
+        provide(container, second, lambda: resolve_key(container, first))
+
+        with pytest.raises(CircularDependencyError, match="first"):
+            resolve_key(container, first)

--- a/packages/pykit-hook/src/pykit_hook/__init__.py
+++ b/packages/pykit-hook/src/pykit_hook/__init__.py
@@ -6,12 +6,15 @@ from pykit_hook.types import (
     Event,
     EventType,
     Handler,
+    HookContext,
     HookEvent,
     HookHandler,
     HookResult,
     Result,
     abort,
+    abort_with_error,
     continue_,
+    continue_with_error,
     modify,
 )
 
@@ -20,6 +23,7 @@ __all__ = [
     "Event",
     "EventType",
     "Handler",
+    "HookContext",
     "HookEvent",
     "HookHandler",
     "HookRegistry",
@@ -27,6 +31,8 @@ __all__ = [
     "Registry",
     "Result",
     "abort",
+    "abort_with_error",
     "continue_",
+    "continue_with_error",
     "modify",
 ]

--- a/packages/pykit-hook/src/pykit_hook/registry.py
+++ b/packages/pykit-hook/src/pykit_hook/registry.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import inspect
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
-from pykit_hook.types import Action, Event, EventType, Handler, Result
+from pykit_hook.types import (
+    Action,
+    Event,
+    EventType,
+    Handler,
+    HookContext,
+    Result,
+    continue_with_error,
+)
+
+type HandlerResult = Result | Awaitable[Result]
 
 
 class Registry:
@@ -38,26 +49,67 @@ class Registry:
 
         return unsubscribe
 
-    def emit(self, event: Event) -> Result:
+    def emit(
+        self,
+        event: Event,
+        context: HookContext | None = None,
+        *,
+        reverse: bool = False,
+    ) -> Result:
         """Emit an event and run all registered handlers sequentially.
-
-        - First ``ABORT`` result short-circuits and returns immediately.
-        - ``MODIFY`` results chain: the ``modified_data`` is carried forward.
-        - If no handlers return ``ABORT`` or ``MODIFY``, returns ``CONTINUE``.
 
         Args:
             event: The hook event to emit.
+            context: Optional context forwarded to context-aware handlers.
+            reverse: Whether to traverse handlers in reverse registration order.
 
         Returns:
             Aggregated hook result.
         """
-        handlers = self._handlers.get(event.type, [])
         last_result = Result()
-        for handler in handlers:
-            result = handler(event)
+        for handler in self._iter_handlers(event.type, reverse=reverse):
+            try:
+                result: Result = self._invoke_handler(handler, event, context)  # type: ignore[assignment]
+            except Exception as exc:
+                result = continue_with_error(exc)
+
             if result.action == Action.ABORT:
                 return result
-            if result.action == Action.MODIFY:
+            if result.action != Action.CONTINUE or result.error is not None:
+                last_result = result
+        return last_result
+
+    async def emit_async(
+        self,
+        event: Event,
+        context: HookContext | None = None,
+        *,
+        reverse: bool = False,
+    ) -> Result:
+        """Emit an event and await any async handlers.
+
+        Args:
+            event: The hook event to emit.
+            context: Optional context forwarded to context-aware handlers.
+            reverse: Whether to traverse handlers in reverse registration order.
+
+        Returns:
+            Aggregated hook result.
+        """
+        last_result = Result()
+        for handler in self._iter_handlers(event.type, reverse=reverse):
+            try:
+                outcome = self._invoke_handler(handler, event, context)
+                if inspect.isawaitable(outcome):
+                    result: Result = await outcome
+                else:
+                    result = outcome
+            except Exception as exc:
+                result = continue_with_error(exc)
+
+            if result.action == Action.ABORT:
+                return result
+            if result.action != Action.CONTINUE or result.error is not None:
                 last_result = result
         return last_result
 
@@ -73,6 +125,33 @@ class Registry:
         else:
             self._handlers.clear()
 
+    def _iter_handlers(self, event_type: EventType, *, reverse: bool = False) -> list[Handler]:
+        handlers = list(self._handlers.get(event_type, []))
+        if reverse:
+            handlers.reverse()
+        return handlers
 
-# Backwards-compatible alias
+    @staticmethod
+    def _invoke_handler(
+        handler: Handler,
+        event: Event,
+        context: HookContext | None,
+    ) -> HandlerResult:
+        signature = inspect.signature(handler)
+        positional = [
+            parameter
+            for parameter in signature.parameters.values()
+            if parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        if (
+            any(
+                parameter.kind == inspect.Parameter.VAR_POSITIONAL
+                for parameter in signature.parameters.values()
+            )
+            or len(positional) >= 2
+        ):
+            return handler(context, event)
+        return handler(event)
+
+
 HookRegistry = Registry

--- a/packages/pykit-hook/src/pykit_hook/types.py
+++ b/packages/pykit-hook/src/pykit_hook/types.py
@@ -3,32 +3,23 @@
 from __future__ import annotations
 
 import enum
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
-
-# ---------------------------------------------------------------------------
-# Event type alias
-# ---------------------------------------------------------------------------
+from typing import Protocol, runtime_checkable
 
 EventType = str
 """String identifier for an event category (e.g. ``"pre_tool_call"``)."""
 
-# ---------------------------------------------------------------------------
-# Event protocol
-# ---------------------------------------------------------------------------
+type HookContext = dict[str, object] | object
+"""Optional context passed to handlers during emission."""
 
 
 @runtime_checkable
 class Event(Protocol):
     """Any object with a ``type`` attribute is a valid hook event."""
 
-    type: EventType
-
-
-# ---------------------------------------------------------------------------
-# Action / Result
-# ---------------------------------------------------------------------------
+    @property
+    def type(self) -> EventType: ...
 
 
 class Action(enum.Enum):
@@ -39,24 +30,19 @@ class Action(enum.Enum):
     MODIFY = "modify"
 
 
-@dataclass
+@dataclass(frozen=True)
 class Result:
     """Result returned by a hook handler."""
 
     action: Action = Action.CONTINUE
-    modified_data: Any = None
+    modified_data: object | None = None
     reason: str = ""
+    error: Exception | None = None
 
 
-# ---------------------------------------------------------------------------
-# Handler type
-# ---------------------------------------------------------------------------
-
-Handler = Callable[[Event], Result]
-
-# ---------------------------------------------------------------------------
-# Convenience factories
-# ---------------------------------------------------------------------------
+# Handler is any callable — the registry inspects the signature at runtime
+# to decide whether to pass (event,) or (context, event).
+type Handler = Callable[..., Result | Awaitable[Result]]
 
 
 def continue_() -> Result:
@@ -64,19 +50,25 @@ def continue_() -> Result:
     return Result()
 
 
+def continue_with_error(err: Exception) -> Result:
+    """Return a CONTINUE result that records an error."""
+    return Result(reason=str(err), error=err)
+
+
 def abort(reason: str = "") -> Result:
     """Return an ABORT result."""
     return Result(action=Action.ABORT, reason=reason)
 
 
-def modify(data: Any, reason: str = "") -> Result:
+def abort_with_error(err: Exception) -> Result:
+    """Return an ABORT result that records an error."""
+    return Result(action=Action.ABORT, reason=str(err), error=err)
+
+
+def modify(data: object, reason: str = "") -> Result:
     """Return a MODIFY result."""
     return Result(action=Action.MODIFY, modified_data=data, reason=reason)
 
-
-# ---------------------------------------------------------------------------
-# Backwards-compatible aliases
-# ---------------------------------------------------------------------------
 
 HookEvent = Event
 HookResult = Result

--- a/packages/pykit-hook/tests/test_hook_context.py
+++ b/packages/pykit-hook/tests/test_hook_context.py
@@ -1,0 +1,66 @@
+"""Context-aware hook tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pykit_hook import Registry, abort_with_error, continue_with_error
+
+PING = "ping"
+
+
+@dataclass(frozen=True)
+class PingEvent:
+    type: str = PING
+
+
+class TestHookContext:
+    def test_emit_passes_context_to_context_handler(self) -> None:
+        registry = Registry()
+        seen: list[dict[str, object] | object | None] = []
+
+        def handler(context: dict[str, object] | object | None, event: PingEvent):
+            seen.append(context)
+            return continue_with_error(RuntimeError(event.type))
+
+        registry.on(PING, handler)
+        result = registry.emit(PingEvent(), {"request_id": "abc"})
+
+        assert seen == [{"request_id": "abc"}]
+        assert isinstance(result.error, RuntimeError)
+        assert str(result.error) == PING
+
+    def test_emit_supports_event_only_handlers(self) -> None:
+        registry = Registry()
+        seen: list[str] = []
+
+        def handler(event: PingEvent):
+            seen.append(event.type)
+            return abort_with_error(RuntimeError("stop"))
+
+        registry.on(PING, handler)
+        result = registry.emit(PingEvent(), object())
+
+        assert seen == [PING]
+        assert result.action.value == "abort"
+        assert str(result.error) == "stop"
+
+    def test_emit_converts_handler_exception_and_continues(self) -> None:
+        registry = Registry()
+        calls: list[str] = []
+
+        def failing(event: PingEvent):
+            calls.append(f"fail:{event.type}")
+            raise RuntimeError("boom")
+
+        def after(context: dict[str, object] | object | None, event: PingEvent):
+            calls.append(f"after:{event.type}")
+            return continue_with_error(ValueError("still running"))
+
+        registry.on(PING, failing)
+        registry.on(PING, after)
+        result = registry.emit(PingEvent(), {"phase": "test"})
+
+        assert calls == ["fail:ping", "after:ping"]
+        assert isinstance(result.error, ValueError)
+        assert str(result.error) == "still running"

--- a/packages/pykit-provider/src/pykit_provider/__init__.py
+++ b/packages/pykit-provider/src/pykit_provider/__init__.py
@@ -12,17 +12,35 @@ from pykit_provider.base import (
     StreamProvider,
 )
 from pykit_provider.func import RequestResponseFunc
+from pykit_provider.middleware import (
+    DuplexMiddleware,
+    Middleware,
+    SinkMiddleware,
+    StreamMiddleware,
+    chain,
+    chain_duplex,
+    chain_sink,
+    chain_stream,
+)
 from pykit_provider.operation_registry import OperationBinding, OperationRegistry
 
 __all__ = [
     "BoxIterator",
     "Duplex",
+    "DuplexMiddleware",
     "DuplexStream",
+    "Middleware",
     "OperationBinding",
     "OperationRegistry",
     "Provider",
     "RequestResponse",
     "RequestResponseFunc",
     "Sink",
+    "SinkMiddleware",
+    "StreamMiddleware",
     "StreamProvider",
+    "chain",
+    "chain_duplex",
+    "chain_sink",
+    "chain_stream",
 ]

--- a/packages/pykit-provider/src/pykit_provider/middleware.py
+++ b/packages/pykit-provider/src/pykit_provider/middleware.py
@@ -1,0 +1,64 @@
+"""Composable middleware helpers for provider shapes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from pykit_provider.base import Duplex, RequestResponse, Sink, StreamProvider
+
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
+
+type Middleware[InputT, OutputT] = Callable[
+    [RequestResponse[InputT, OutputT]], RequestResponse[InputT, OutputT]
+]
+type SinkMiddleware[InputT] = Callable[[Sink[InputT]], Sink[InputT]]
+type StreamMiddleware[InputT, OutputT] = Callable[
+    [StreamProvider[InputT, OutputT]], StreamProvider[InputT, OutputT]
+]
+type DuplexMiddleware[InputT, OutputT] = Callable[[Duplex[InputT, OutputT]], Duplex[InputT, OutputT]]
+
+
+def chain(*middlewares: Middleware[InputT, OutputT]) -> Middleware[InputT, OutputT]:
+    """Compose request/response middleware left-to-right."""
+
+    def combined(inner: RequestResponse[InputT, OutputT]) -> RequestResponse[InputT, OutputT]:
+        for middleware in reversed(middlewares):
+            inner = middleware(inner)
+        return inner
+
+    return combined
+
+
+def chain_sink(*middlewares: SinkMiddleware[InputT]) -> SinkMiddleware[InputT]:
+    """Compose sink middleware left-to-right."""
+
+    def combined(inner: Sink[InputT]) -> Sink[InputT]:
+        for middleware in reversed(middlewares):
+            inner = middleware(inner)
+        return inner
+
+    return combined
+
+
+def chain_stream(*middlewares: StreamMiddleware[InputT, OutputT]) -> StreamMiddleware[InputT, OutputT]:
+    """Compose stream middleware left-to-right."""
+
+    def combined(inner: StreamProvider[InputT, OutputT]) -> StreamProvider[InputT, OutputT]:
+        for middleware in reversed(middlewares):
+            inner = middleware(inner)
+        return inner
+
+    return combined
+
+
+def chain_duplex(*middlewares: DuplexMiddleware[InputT, OutputT]) -> DuplexMiddleware[InputT, OutputT]:
+    """Compose duplex middleware left-to-right."""
+
+    def combined(inner: Duplex[InputT, OutputT]) -> Duplex[InputT, OutputT]:
+        for middleware in reversed(middlewares):
+            inner = middleware(inner)
+        return inner
+
+    return combined

--- a/packages/pykit-provider/tests/test_middleware.py
+++ b/packages/pykit-provider/tests/test_middleware.py
@@ -1,0 +1,222 @@
+"""Middleware chaining tests for provider shapes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from pykit_provider import (
+    BoxIterator,
+    Duplex,
+    DuplexStream,
+    RequestResponse,
+    Sink,
+    StreamProvider,
+    chain,
+    chain_duplex,
+    chain_sink,
+    chain_stream,
+)
+
+
+@dataclass
+class RecordingIterator(BoxIterator[str]):
+    items: list[str]
+    index: int = 0
+
+    async def next(self) -> str | None:
+        if self.index >= len(self.items):
+            return None
+        value = self.items[self.index]
+        self.index += 1
+        return value
+
+
+class EchoRequestResponse:
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def execute(self, input: str) -> str:
+        return input
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return "sink"
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def send(self, input: str) -> None:
+        self.messages.append(input)
+
+
+class WordStream:
+    @property
+    def name(self) -> str:
+        return "stream"
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def execute(self, input: str) -> RecordingIterator:
+        return RecordingIterator(input.split())
+
+
+class MemoryDuplexStream(DuplexStream[str, str]):
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send(self, input: str) -> None:
+        self.sent.append(input)
+
+    async def recv(self) -> str | None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+class MemoryDuplex:
+    def __init__(self) -> None:
+        self.stream = MemoryDuplexStream()
+
+    @property
+    def name(self) -> str:
+        return "duplex"
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def open(self) -> MemoryDuplexStream:
+        return self.stream
+
+
+def wrap_request_response(label: str, order: list[str]):
+    def middleware(inner: RequestResponse[str, str]) -> RequestResponse[str, str]:
+        class Wrapped:
+            @property
+            def name(self) -> str:
+                return inner.name
+
+            async def is_available(self) -> bool:
+                return await inner.is_available()
+
+            async def execute(self, input: str) -> str:
+                order.append(label)
+                return await inner.execute(input)
+
+        return Wrapped()
+
+    return middleware
+
+
+def wrap_sink(label: str, order: list[str]):
+    def middleware(inner: Sink[str]) -> Sink[str]:
+        class Wrapped:
+            @property
+            def name(self) -> str:
+                return inner.name
+
+            async def is_available(self) -> bool:
+                return await inner.is_available()
+
+            async def send(self, input: str) -> None:
+                order.append(label)
+                await inner.send(input)
+
+        return Wrapped()
+
+    return middleware
+
+
+def wrap_stream(label: str, order: list[str]):
+    def middleware(inner: StreamProvider[str, str]) -> StreamProvider[str, str]:
+        class Wrapped:
+            @property
+            def name(self) -> str:
+                return inner.name
+
+            async def is_available(self) -> bool:
+                return await inner.is_available()
+
+            async def execute(self, input: str) -> RecordingIterator:
+                order.append(label)
+                return await inner.execute(input)
+
+        return Wrapped()
+
+    return middleware
+
+
+def wrap_duplex(label: str, order: list[str]):
+    def middleware(inner: Duplex[str, str]) -> Duplex[str, str]:
+        class Wrapped:
+            @property
+            def name(self) -> str:
+                return inner.name
+
+            async def is_available(self) -> bool:
+                return await inner.is_available()
+
+            async def open(self) -> DuplexStream[str, str]:
+                order.append(label)
+                return await inner.open()
+
+        return Wrapped()
+
+    return middleware
+
+
+class TestMiddlewareChains:
+    @pytest.mark.asyncio
+    async def test_request_response_chain_left_to_right(self) -> None:
+        order: list[str] = []
+        provider = chain(
+            wrap_request_response("first", order),
+            wrap_request_response("second", order),
+        )(EchoRequestResponse())
+
+        assert await provider.execute("hello") == "hello"
+        assert order == ["first", "second"]
+
+    @pytest.mark.asyncio
+    async def test_sink_chain_left_to_right(self) -> None:
+        order: list[str] = []
+        sink = RecordingSink()
+        wrapped = chain_sink(wrap_sink("first", order), wrap_sink("second", order))(sink)
+
+        await wrapped.send("payload")
+
+        assert order == ["first", "second"]
+        assert sink.messages == ["payload"]
+
+    @pytest.mark.asyncio
+    async def test_stream_chain_left_to_right(self) -> None:
+        order: list[str] = []
+        provider = chain_stream(wrap_stream("first", order), wrap_stream("second", order))(WordStream())
+
+        iterator = await provider.execute("one two")
+        assert [item async for item in iterator] == ["one", "two"]
+        assert order == ["first", "second"]
+
+    @pytest.mark.asyncio
+    async def test_duplex_chain_left_to_right(self) -> None:
+        order: list[str] = []
+        duplex = MemoryDuplex()
+        wrapped = chain_duplex(wrap_duplex("first", order), wrap_duplex("second", order))(duplex)
+
+        stream = await wrapped.open()
+        await stream.send("hello")
+
+        assert order == ["first", "second"]
+        assert duplex.stream.sent == ["hello"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = []
 dev = [
     "pykit",
     "pykit-auth",
+    "pykit-auth-apikey",
+    "pykit-chain",
     "pykit-errors",
     "pykit-config",
     "pykit-integration",
@@ -103,7 +105,9 @@ pykit                = { workspace = true }
 pykit-agent          = { workspace = true }
 pykit-llm-providers = { workspace = true }
 pykit-auth           = { workspace = true }
+pykit-auth-apikey    = { workspace = true }
 pykit-auth-oidc      = { workspace = true }
+pykit-chain          = { workspace = true }
 pykit-authz          = { workspace = true }
 pykit-integration    = { workspace = true }
 pykit-bench          = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -2299,6 +2299,7 @@ source = { editable = "packages/pykit-bootstrap" }
 dependencies = [
     { name = "pykit-component" },
     { name = "pykit-errors" },
+    { name = "pykit-hook" },
     { name = "pykit-logging" },
 ]
 
@@ -2306,6 +2307,7 @@ dependencies = [
 requires-dist = [
     { name = "pykit-component", editable = "packages/pykit-component" },
     { name = "pykit-errors", editable = "packages/pykit-errors" },
+    { name = "pykit-hook", editable = "packages/pykit-hook" },
     { name = "pykit-logging", editable = "packages/pykit-logging" },
 ]
 
@@ -3113,10 +3115,12 @@ dev = [
     { name = "pykit" },
     { name = "pykit-agent" },
     { name = "pykit-auth" },
+    { name = "pykit-auth-apikey" },
     { name = "pykit-auth-oidc" },
     { name = "pykit-authz" },
     { name = "pykit-bench" },
     { name = "pykit-bootstrap" },
+    { name = "pykit-chain" },
     { name = "pykit-component" },
     { name = "pykit-config" },
     { name = "pykit-dag" },
@@ -3185,10 +3189,12 @@ dev = [
     { name = "pykit", editable = "packages/pykit" },
     { name = "pykit-agent", editable = "packages/pykit-agent" },
     { name = "pykit-auth", editable = "packages/pykit-auth" },
+    { name = "pykit-auth-apikey", editable = "packages/pykit-auth-apikey" },
     { name = "pykit-auth-oidc", editable = "packages/pykit-auth-oidc" },
     { name = "pykit-authz", editable = "packages/pykit-authz" },
     { name = "pykit-bench", editable = "packages/pykit-bench" },
     { name = "pykit-bootstrap", editable = "packages/pykit-bootstrap" },
+    { name = "pykit-chain", editable = "packages/pykit-chain" },
     { name = "pykit-component", editable = "packages/pykit-component" },
     { name = "pykit-config", editable = "packages/pykit-config" },
     { name = "pykit-dag", editable = "packages/pykit-dag" },


### PR DESCRIPTION
## Description

Align Group 02 L2 modules per cross-kit lifecycle review. Enhances component/hook/DI/provider and migrates bootstrap to use `hook.Registry`.

## Motivation

Cross-kit alignment of the L2 pattern/contract layer per `02-component-lifecycle-di.md` review. These modules define the composition substrate for all higher-layer modules.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)

## Package(s) Affected

- pykit-component
- pykit-hook
- pykit-di
- pykit-provider
- pykit-bootstrap

## Changes Made

### pykit-component
- `State` IntEnum: CREATED, STARTING, RUNNING, STOPPING, STOPPED, FAILED
- `Registry` rewritten with state tracking, rollback on partial start, `stop_all_detailed()`
- `StopResult` dataclass for structured shutdown errors
- Snapshot-based `health_all()` to avoid lock contention

### pykit-hook
- `Result` gains `error` field with `continue_with_error`/`abort_with_error`
- Exception recovery per handler in `emit()`
- Context-aware dispatch (handlers can accept context as first param)

### pykit-di
- `Transient` registration mode (no caching)
- `ContextVar`-based circular dependency detection
- Typed `Key[T]` API: `provide`, `provide_singleton`, `provide_transient`, `resolve_key`, `must_resolve_key`

### pykit-provider
- `Middleware[I,O]`, `StreamMiddleware[I,O]`, `SinkMiddleware[I]`, `DuplexMiddleware[I,O]`
- Chain functions: `chain`, `chain_stream`, `chain_sink`, `chain_duplex`

### pykit-bootstrap
- Migrate from ad-hoc `Lifecycle` to `hook.Registry`
- `LifecycleEvent` with `EVENT_START`/`EVENT_READY`/`EVENT_STOP`
- Startup order aligned: configure → start_all → on_start → ready_check → on_ready
- Partial rollback on startup failure
- Optional logger injection

## Testing

- [x] Added new tests for my changes
- [x] All existing tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check packages/`)

## Breaking Changes

- Bootstrap startup order changed (configure before start_all)
- `Lifecycle` class replaced with `hook.Registry`-based dispatch
- All pre-stable (alpha) — no backward compatibility required

## Sibling Parity

- [x] Sibling-parity tracked: aligned with gokit and rskit Group 02 changes

## Checklist

- [x] My code follows the coding standards in CONTRIBUTING.md
- [x] I have added Google-style docstrings for new public functions/classes
- [x] I have added tests that prove my fix/feature works
- [x] New dependencies: none (pykit-hook is already a workspace dep)
