### PR TITLE
Refactor storage backend registration

### DIFF
--- a/packages/pykit-cache/README.md
+++ b/packages/pykit-cache/README.md
@@ -1,59 +1,57 @@
 # pykit-cache
 
-Async cache client with component lifecycle, health checking, and a generic typed JSON store.
+Async cache abstraction with an in-memory lean default, explicit backend registries, component
+lifecycle, and a generic typed JSON store.
 
 ## Installation
 
 ```bash
 pip install pykit-cache
-# or
+pip install 'pykit-cache[redis]'  # optional Redis adapter
+
 uv add pykit-cache
+uv add 'pykit-cache[redis]'  # optional Redis adapter
 ```
 
 ## Quick Start
 
 ```python
-from pykit_cache import CacheConfig, CacheComponent, TypedStore
+from pykit_cache import CacheComponent, CacheConfig, TypedStore
 
-# Create and start the cache component
-config = CacheConfig(url="redis://localhost:6379/0", max_connections=20)
-component = CacheComponent(config)
+component = CacheComponent(CacheConfig())  # default backend="memory"
 await component.start()
 
-# Use the client directly
 client = component.client
 await client.set("key", "value", ex=300)
-val = await client.get("key")  # "value"
+assert await client.get("key") == "value"
 
-# JSON operations
-await client.set_json("user:1", {"name": "Alice", "role": "admin"})
-user = await client.get_json("user:1")  # {"name": "Alice", "role": "admin"}
-
-# Typed store with key prefix
 store: TypedStore[dict] = TypedStore(client, key_prefix="sessions")
 await store.save("abc", {"user_id": 42}, ttl=3600)
-session = await store.load("abc")  # {"user_id": 42}
+```
 
-# Health check
-health = await component.health()  # Health(status=HEALTHY, ...)
+## Explicit Redis registration
 
-await component.stop()
+Redis is optional and is never imported or registered by the core package.
+
+```python
+from pykit_cache import CacheComponent, CacheConfig, CacheRegistry, register_memory
+from pykit_cache.redis import register as register_redis
+
+registry = CacheRegistry()
+register_memory(registry)
+register_redis(registry)
+
+component = CacheComponent(
+    CacheConfig(backend="redis", url="redis://localhost:6379/0"),
+    registry=registry,
+)
+await component.start()
 ```
 
 ## Key Components
 
-- **CacheConfig** — Configuration dataclass (url, password, db, max_connections, timeouts, retry settings)
-- **CacheClient** — Thin async wrapper around `redis.asyncio.Redis` with `get`, `set`, `delete`, `exists`, `get_json`, `set_json`, `ping`, and `unwrap()` for raw access
-- **CacheComponent** — Lifecycle-managed component with `start()`, `stop()`, and `health()` (implements Component protocol)
-- **TypedStore[T]** — Generic JSON-serialized key-value store with optional key prefix and TTL support
-
-## Dependencies
-
-- `pykit-errors`, `pykit-component`
-- `redis` (redis-py async client)
-- Optional: `pykit-testutil` (for testing)
-
-## See Also
-
-- [Main pykit README](../../README.md)
-- [tests/](tests/) — additional usage examples
+- **CacheConfig** — backend selection plus memory and Redis adapter settings.
+- **CacheRegistry** — injected registry; a new empty registry has no backends.
+- **InMemoryCache** — bounded in-process LRU cache with TTL support.
+- **CacheClient** — backend-agnostic async `get`, `set`, `delete`, `exists`, JSON helpers.
+- **TypedStore[T]** — JSON-serialized key-value store with optional key prefix.

--- a/packages/pykit-cache/pyproject.toml
+++ b/packages/pykit-cache/pyproject.toml
@@ -1,19 +1,19 @@
 [project]
 name = "pykit-cache"
-description = "cache client and caching utilities with component lifecycle"
+description = "cache abstraction with in-memory default and optional adapters"
 version = "0.1.0"
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["cache", "redis", "client", "async"]
+keywords = ["cache", "client", "async"]
 requires-python = ">=3.13"
 dependencies = [
-    "redis",
     "pykit-errors",
     "pykit-component",
     "pykit-util",
 ]
 
 [project.optional-dependencies]
+redis = ["redis"]
 test = ["pykit-testutil"]
 
 [build-system]

--- a/packages/pykit-cache/src/pykit_cache/__init__.py
+++ b/packages/pykit-cache/src/pykit_cache/__init__.py
@@ -1,15 +1,22 @@
-"""pykit-cache — Async cache client with component lifecycle and typed store."""
+"""pykit-cache — Async cache abstraction with lean in-memory default."""
 
 from __future__ import annotations
 
+from pykit_cache.backends import CacheBackend, InMemoryCache
 from pykit_cache.client import CacheClient
 from pykit_cache.component import CacheComponent
 from pykit_cache.config import CacheConfig
+from pykit_cache.registry import CacheRegistry, default_cache_registry, register_memory
 from pykit_cache.typed_store import TypedStore
 
 __all__ = [
+    "CacheBackend",
     "CacheClient",
     "CacheComponent",
     "CacheConfig",
+    "CacheRegistry",
+    "InMemoryCache",
     "TypedStore",
+    "default_cache_registry",
+    "register_memory",
 ]

--- a/packages/pykit-cache/src/pykit_cache/backends.py
+++ b/packages/pykit-cache/src/pykit_cache/backends.py
@@ -1,0 +1,103 @@
+"""Cache backend protocols and in-memory default implementation."""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from pykit_cache.config import CacheConfig
+from pykit_errors import InvalidInputError
+
+
+@runtime_checkable
+class CacheBackend(Protocol):
+    """Async key-value cache backend contract."""
+
+    async def get(self, key: str) -> str | None: ...
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None: ...
+
+    async def delete(self, *keys: str) -> int: ...
+
+    async def exists(self, *keys: str) -> int: ...
+
+    async def ping(self) -> bool: ...
+
+    async def close(self) -> None: ...
+
+
+CacheFactory = Callable[[CacheConfig], CacheBackend]
+
+
+@dataclass
+class _CacheEntry:
+    value: str
+    expires_at: float | None
+
+
+class InMemoryCache:
+    """Lean in-process cache backend with TTL and bounded LRU eviction."""
+
+    def __init__(self, *, default_ttl_seconds: int | None = None, max_entries: int = 10_000) -> None:
+        if default_ttl_seconds is not None and default_ttl_seconds <= 0:
+            raise InvalidInputError("default_ttl_seconds must be positive", field="default_ttl_seconds")
+        if max_entries <= 0:
+            raise InvalidInputError("max_entries must be positive", field="max_entries")
+        self._default_ttl_seconds = default_ttl_seconds
+        self._max_entries = max_entries
+        self._entries: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self._closed = False
+
+    async def get(self, key: str) -> str | None:
+        """Return a cached value or ``None`` when missing/expired."""
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        if self._is_expired(entry):
+            del self._entries[key]
+            return None
+        self._entries.move_to_end(key)
+        return entry.value
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        """Store a value with optional Redis-compatible expiry seconds."""
+        ttl = self._default_ttl_seconds if ex is None else ex
+        if ttl is not None and ttl <= 0:
+            raise InvalidInputError("cache TTL must be positive", field="ttl")
+        expires_at = None if ttl is None else time.monotonic() + ttl
+        self._entries[key] = _CacheEntry(value=value, expires_at=expires_at)
+        self._entries.move_to_end(key)
+        while len(self._entries) > self._max_entries:
+            self._entries.popitem(last=False)
+
+    async def delete(self, *keys: str) -> int:
+        """Delete keys and return the number removed."""
+        removed = 0
+        for key in keys:
+            if key in self._entries:
+                del self._entries[key]
+                removed += 1
+        return removed
+
+    async def exists(self, *keys: str) -> int:
+        """Return the number of provided keys that currently exist."""
+        count = 0
+        for key in keys:
+            if await self.get(key) is not None:
+                count += 1
+        return count
+
+    async def ping(self) -> bool:
+        """Return cache health."""
+        return not self._closed
+
+    async def close(self) -> None:
+        """Close the backend and clear process-local state."""
+        self._closed = True
+        self._entries.clear()
+
+    def _is_expired(self, entry: _CacheEntry) -> bool:
+        return entry.expires_at is not None and time.monotonic() >= entry.expires_at

--- a/packages/pykit-cache/src/pykit_cache/backends.py
+++ b/packages/pykit-cache/src/pykit_cache/backends.py
@@ -16,17 +16,23 @@ from pykit_errors import InvalidInputError
 class CacheBackend(Protocol):
     """Async key-value cache backend contract."""
 
-    async def get(self, key: str) -> str | None: ...
+    async def get(self, key: str) -> str | None:
+        raise NotImplementedError
 
-    async def set(self, key: str, value: str, ex: int | None = None) -> None: ...
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        raise NotImplementedError
 
-    async def delete(self, *keys: str) -> int: ...
+    async def delete(self, *keys: str) -> int:
+        raise NotImplementedError
 
-    async def exists(self, *keys: str) -> int: ...
+    async def exists(self, *keys: str) -> int:
+        raise NotImplementedError
 
-    async def ping(self) -> bool: ...
+    async def ping(self) -> bool:
+        raise NotImplementedError
 
-    async def close(self) -> None: ...
+    async def close(self) -> None:
+        raise NotImplementedError
 
 
 CacheFactory = Callable[[CacheConfig], CacheBackend]

--- a/packages/pykit-cache/src/pykit_cache/client.py
+++ b/packages/pykit-cache/src/pykit_cache/client.py
@@ -65,6 +65,6 @@ class CacheClient:
         """Close the underlying backend."""
         await self._backend.close()
 
-    def unwrap(self) -> object:
+    def unwrap(self) -> CacheBackend:
         """Access the underlying backend."""
         return self._backend

--- a/packages/pykit-cache/src/pykit_cache/client.py
+++ b/packages/pykit-cache/src/pykit_cache/client.py
@@ -1,36 +1,35 @@
-"""Async cache client wrapping redis.asyncio.Redis."""
+"""Async cache client over an injected backend."""
 
 from __future__ import annotations
 
-from typing import Any, TypeVar, cast
+from inspect import isawaitable
+from typing import TypeVar
 
-import redis.asyncio as aioredis
-
+from pykit_cache.backends import CacheBackend
 from pykit_cache.config import CacheConfig
+from pykit_cache.registry import CacheRegistry, default_cache_registry
 from pykit_util import JsonCodec
 
 T = TypeVar("T")
 
 
 class CacheClient:
-    """Thin async wrapper around :class:`redis.asyncio.Redis`."""
+    """Async cache client with JSON helpers."""
 
-    def __init__(self, config: CacheConfig) -> None:
-        self._config = config
-        self._redis = aioredis.Redis.from_url(
-            config.url,
-            password=config.password or None,
-            db=config.db,
-            max_connections=config.max_connections,
-            socket_timeout=config.socket_timeout,
-            socket_connect_timeout=config.socket_connect_timeout,
-            retry_on_timeout=config.retry_on_timeout,
-            decode_responses=config.decode_responses,
-        )
+    def __init__(
+        self,
+        config: CacheConfig | None = None,
+        *,
+        backend: CacheBackend | None = None,
+        registry: CacheRegistry | None = None,
+    ) -> None:
+        self._config = config or CacheConfig()
+        self._backend = backend or (registry or default_cache_registry()).create(self._config)
+        self._redis = self._backend
 
     async def get(self, key: str) -> str | None:
         """Retrieve a value by key."""
-        return cast("str | None", await self._redis.get(key))
+        return await self._redis.get(key)
 
     async def set(self, key: str, value: str, ex: int | None = None) -> None:
         """Store a value with optional expiration in seconds."""
@@ -38,34 +37,35 @@ class CacheClient:
 
     async def delete(self, *keys: str) -> int:
         """Delete one or more keys. Returns number of keys removed."""
-        return cast("int", await self._redis.delete(*keys))
+        return await self._redis.delete(*keys)
 
     async def exists(self, *keys: str) -> int:
         """Return the number of provided keys that exist."""
-        return cast("int", await self._redis.exists(*keys))
+        return await self._redis.exists(*keys)
 
     async def get_json(self, key: str, type_hint: type[T] = dict) -> T | None:  # type: ignore[assignment]
         """Get a key and JSON-decode the value."""
+        _ = type_hint
         raw = await self.get(key)
         if raw is None:
             return None
         return JsonCodec[T](stringify_unknown=False).decode(raw)
 
-    async def set_json(self, key: str, value: Any, ex: int | None = None) -> None:
+    async def set_json(self, key: str, value: object, ex: int | None = None) -> None:
         """JSON-encode *value* and store it."""
-        await self.set(key, JsonCodec[Any](stringify_unknown=False).encode(value).decode(), ex=ex)
+        await self.set(key, JsonCodec[object](stringify_unknown=False).encode(value).decode(), ex=ex)
 
     async def ping(self) -> bool:
-        """Return ``True`` if the server responds to PING."""
+        """Return ``True`` when the backend is healthy."""
         result = self._redis.ping()
-        if hasattr(result, "__await__"):
-            return cast("bool", await result)
+        if isawaitable(result):
+            return bool(await result)
         return bool(result)
 
     async def close(self) -> None:
-        """Close the underlying connection pool."""
-        await self._redis.aclose()
+        """Close the underlying backend."""
+        await self._backend.close()
 
-    def unwrap(self) -> aioredis.Redis:
-        """Access the underlying :class:`redis.asyncio.Redis` instance."""
+    def unwrap(self) -> object:
+        """Access the underlying backend."""
         return self._redis

--- a/packages/pykit-cache/src/pykit_cache/client.py
+++ b/packages/pykit-cache/src/pykit_cache/client.py
@@ -25,23 +25,22 @@ class CacheClient:
     ) -> None:
         self._config = config or CacheConfig()
         self._backend = backend or (registry or default_cache_registry()).create(self._config)
-        self._redis = self._backend
 
     async def get(self, key: str) -> str | None:
         """Retrieve a value by key."""
-        return await self._redis.get(key)
+        return await self._backend.get(key)
 
     async def set(self, key: str, value: str, ex: int | None = None) -> None:
         """Store a value with optional expiration in seconds."""
-        await self._redis.set(key, value, ex=ex)
+        await self._backend.set(key, value, ex=ex)
 
     async def delete(self, *keys: str) -> int:
         """Delete one or more keys. Returns number of keys removed."""
-        return await self._redis.delete(*keys)
+        return await self._backend.delete(*keys)
 
     async def exists(self, *keys: str) -> int:
         """Return the number of provided keys that exist."""
-        return await self._redis.exists(*keys)
+        return await self._backend.exists(*keys)
 
     async def get_json(self, key: str, type_hint: type[T] = dict) -> T | None:  # type: ignore[assignment]
         """Get a key and JSON-decode the value."""
@@ -57,7 +56,7 @@ class CacheClient:
 
     async def ping(self) -> bool:
         """Return ``True`` when the backend is healthy."""
-        result = self._redis.ping()
+        result = self._backend.ping()
         if isawaitable(result):
             return bool(await result)
         return bool(result)
@@ -68,4 +67,4 @@ class CacheClient:
 
     def unwrap(self) -> object:
         """Access the underlying backend."""
-        return self._redis
+        return self._backend

--- a/packages/pykit-cache/src/pykit_cache/component.py
+++ b/packages/pykit-cache/src/pykit_cache/component.py
@@ -39,6 +39,8 @@ class CacheComponent:
 
     async def health(self) -> Health:
         """Return current health status."""
+        if not self._config.enabled:
+            return Health(name=self.name, status=HealthStatus.HEALTHY, message="cache disabled")
         if self._client is None:
             return Health(
                 name=self.name,

--- a/packages/pykit-cache/src/pykit_cache/component.py
+++ b/packages/pykit-cache/src/pykit_cache/component.py
@@ -1,17 +1,19 @@
-"""cache component with lifecycle management."""
+"""Cache component with lifecycle management."""
 
 from __future__ import annotations
 
 from pykit_cache.client import CacheClient
 from pykit_cache.config import CacheConfig
+from pykit_cache.registry import CacheRegistry, default_cache_registry
 from pykit_component import Health, HealthStatus
 
 
 class CacheComponent:
     """Lifecycle-managed cache component implementing the Component protocol."""
 
-    def __init__(self, config: CacheConfig) -> None:
-        self._config = config
+    def __init__(self, config: CacheConfig | None = None, *, registry: CacheRegistry | None = None) -> None:
+        self._config = config or CacheConfig()
+        self._registry = registry or default_cache_registry()
         self._client: CacheClient | None = None
 
     @property
@@ -23,14 +25,14 @@ class CacheComponent:
         return self._client
 
     async def start(self) -> None:
-        """Create the client and verify connectivity with a PING."""
+        """Create the client and verify backend health."""
         if not self._config.enabled:
             return
-        self._client = CacheClient(self._config)
+        self._client = CacheClient(self._config, registry=self._registry)
         await self._client.ping()
 
     async def stop(self) -> None:
-        """Close the underlying cache connection."""
+        """Close the underlying cache backend."""
         if self._client is not None:
             await self._client.close()
             self._client = None
@@ -44,11 +46,13 @@ class CacheComponent:
                 message="cache not initialized",
             )
         try:
-            await self._client.ping()
+            ok = await self._client.ping()
         except Exception as exc:
             return Health(
                 name=self.name,
                 status=HealthStatus.UNHEALTHY,
                 message=f"ping failed: {exc}",
             )
+        if not ok:
+            return Health(name=self.name, status=HealthStatus.UNHEALTHY, message="ping failed")
         return Health(name=self.name, status=HealthStatus.HEALTHY)

--- a/packages/pykit-cache/src/pykit_cache/component.py
+++ b/packages/pykit-cache/src/pykit_cache/component.py
@@ -29,9 +29,11 @@ class CacheComponent:
         """Create the client and verify backend health."""
         if not self._config.enabled:
             return
-        self._client = CacheClient(self._config, registry=self._registry)
-        if not await self._client.ping():
+        client = CacheClient(self._config, registry=self._registry)
+        if not await client.ping():
+            await client.close()
             raise ServiceUnavailableError(self.name, "ping failed")
+        self._client = client
 
     async def stop(self) -> None:
         """Close the underlying cache backend."""

--- a/packages/pykit-cache/src/pykit_cache/component.py
+++ b/packages/pykit-cache/src/pykit_cache/component.py
@@ -6,6 +6,7 @@ from pykit_cache.client import CacheClient
 from pykit_cache.config import CacheConfig
 from pykit_cache.registry import CacheRegistry, default_cache_registry
 from pykit_component import Health, HealthStatus
+from pykit_errors import ServiceUnavailableError
 
 
 class CacheComponent:
@@ -29,7 +30,8 @@ class CacheComponent:
         if not self._config.enabled:
             return
         self._client = CacheClient(self._config, registry=self._registry)
-        await self._client.ping()
+        if not await self._client.ping():
+            raise ServiceUnavailableError(self.name, "ping failed")
 
     async def stop(self) -> None:
         """Close the underlying cache backend."""

--- a/packages/pykit-cache/src/pykit_cache/config.py
+++ b/packages/pykit-cache/src/pykit_cache/config.py
@@ -1,4 +1,4 @@
-"""cache configuration."""
+"""Cache configuration."""
 
 from __future__ import annotations
 
@@ -7,9 +7,15 @@ from dataclasses import dataclass
 
 @dataclass
 class CacheConfig:
-    """Connection and pool configuration for cache."""
+    """Configuration for selecting and constructing a cache backend."""
 
     name: str = "cache"
+    backend: str = "memory"
+    enabled: bool = True
+    default_ttl_seconds: int | None = None
+    max_entries: int = 10_000
+
+    # Redis adapter settings. Used only by pykit_cache.redis after explicit registration.
     url: str = "redis://localhost:6379/0"
     password: str = ""
     db: int = 0
@@ -18,4 +24,3 @@ class CacheConfig:
     socket_connect_timeout: float = 5.0
     retry_on_timeout: bool = True
     decode_responses: bool = True
-    enabled: bool = True

--- a/packages/pykit-cache/src/pykit_cache/redis.py
+++ b/packages/pykit-cache/src/pykit_cache/redis.py
@@ -16,17 +16,23 @@ if TYPE_CHECKING:
 class RedisClient(Protocol):
     """Subset of the Redis async client used by the cache adapter."""
 
-    def get(self, key: str) -> Awaitable[object]: ...
+    def get(self, key: str) -> Awaitable[object]:
+        raise NotImplementedError
 
-    def set(self, key: str, value: str, *, ex: int | None = None) -> Awaitable[object]: ...
+    def set(self, key: str, value: str, *, ex: int | None = None) -> Awaitable[object]:
+        raise NotImplementedError
 
-    def delete(self, *keys: str) -> Awaitable[object]: ...
+    def delete(self, *keys: str) -> Awaitable[object]:
+        raise NotImplementedError
 
-    def exists(self, *keys: str) -> Awaitable[object]: ...
+    def exists(self, *keys: str) -> Awaitable[object]:
+        raise NotImplementedError
 
-    def ping(self) -> Awaitable[object] | object: ...
+    def ping(self) -> Awaitable[object] | object:
+        raise NotImplementedError
 
-    def aclose(self) -> Awaitable[None]: ...
+    def aclose(self) -> Awaitable[None]:
+        raise NotImplementedError
 
 
 class RedisCacheBackend:

--- a/packages/pykit-cache/src/pykit_cache/redis.py
+++ b/packages/pykit-cache/src/pykit_cache/redis.py
@@ -8,6 +8,7 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING, Protocol, cast
 
 from pykit_cache.config import CacheConfig
+from pykit_errors import InvalidInputError
 
 if TYPE_CHECKING:
     from pykit_cache.registry import CacheRegistry
@@ -42,6 +43,11 @@ class RedisCacheBackend:
     """
 
     def __init__(self, config: CacheConfig) -> None:
+        if not config.decode_responses:
+            raise InvalidInputError(
+                "Redis cache backend requires decode_responses=True",
+                field="decode_responses",
+            )
         try:
             aioredis = importlib.import_module("redis.asyncio")
         except ImportError as exc:

--- a/packages/pykit-cache/src/pykit_cache/redis.py
+++ b/packages/pykit-cache/src/pykit_cache/redis.py
@@ -2,15 +2,31 @@
 
 from __future__ import annotations
 
+import importlib
+from collections.abc import Awaitable
 from inspect import isawaitable
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Protocol, cast
 
 from pykit_cache.config import CacheConfig
 
 if TYPE_CHECKING:
-    from redis.asyncio import Redis
-
     from pykit_cache.registry import CacheRegistry
+
+
+class RedisClient(Protocol):
+    """Subset of the Redis async client used by the cache adapter."""
+
+    def get(self, key: str) -> Awaitable[object]: ...
+
+    def set(self, key: str, value: str, *, ex: int | None = None) -> Awaitable[object]: ...
+
+    def delete(self, *keys: str) -> Awaitable[object]: ...
+
+    def exists(self, *keys: str) -> Awaitable[object]: ...
+
+    def ping(self) -> Awaitable[object] | object: ...
+
+    def aclose(self) -> Awaitable[None]: ...
 
 
 class RedisCacheBackend:
@@ -21,20 +37,23 @@ class RedisCacheBackend:
 
     def __init__(self, config: CacheConfig) -> None:
         try:
-            import redis.asyncio as aioredis
+            aioredis = importlib.import_module("redis.asyncio")
         except ImportError as exc:
             msg = "redis is required for RedisCacheBackend; install pykit-cache[redis]"
             raise ImportError(msg) from exc
 
-        self._redis: Redis = aioredis.Redis.from_url(
-            config.url,
-            password=config.password or None,
-            db=config.db,
-            max_connections=config.max_connections,
-            socket_timeout=config.socket_timeout,
-            socket_connect_timeout=config.socket_connect_timeout,
-            retry_on_timeout=config.retry_on_timeout,
-            decode_responses=config.decode_responses,
+        self._redis = cast(
+            "RedisClient",
+            aioredis.Redis.from_url(
+                config.url,
+                password=config.password or None,
+                db=config.db,
+                max_connections=config.max_connections,
+                socket_timeout=config.socket_timeout,
+                socket_connect_timeout=config.socket_connect_timeout,
+                retry_on_timeout=config.retry_on_timeout,
+                decode_responses=config.decode_responses,
+            ),
         )
 
     async def get(self, key: str) -> str | None:
@@ -64,7 +83,7 @@ class RedisCacheBackend:
         """Close the underlying connection pool."""
         await self._redis.aclose()
 
-    def unwrap(self) -> Redis:
+    def unwrap(self) -> RedisClient:
         """Access the underlying Redis client."""
         return self._redis
 

--- a/packages/pykit-cache/src/pykit_cache/redis.py
+++ b/packages/pykit-cache/src/pykit_cache/redis.py
@@ -1,0 +1,74 @@
+"""Optional Redis cache adapter."""
+
+from __future__ import annotations
+
+from inspect import isawaitable
+from typing import TYPE_CHECKING, cast
+
+from pykit_cache.config import CacheConfig
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+    from pykit_cache.registry import CacheRegistry
+
+
+class RedisCacheBackend:
+    """Redis-backed cache backend.
+
+    Requires the ``redis`` extra and explicit ``register(registry)`` before config selection.
+    """
+
+    def __init__(self, config: CacheConfig) -> None:
+        try:
+            import redis.asyncio as aioredis
+        except ImportError as exc:
+            msg = "redis is required for RedisCacheBackend; install pykit-cache[redis]"
+            raise ImportError(msg) from exc
+
+        self._redis: Redis = aioredis.Redis.from_url(
+            config.url,
+            password=config.password or None,
+            db=config.db,
+            max_connections=config.max_connections,
+            socket_timeout=config.socket_timeout,
+            socket_connect_timeout=config.socket_connect_timeout,
+            retry_on_timeout=config.retry_on_timeout,
+            decode_responses=config.decode_responses,
+        )
+
+    async def get(self, key: str) -> str | None:
+        """Retrieve a value by key."""
+        return cast("str | None", await self._redis.get(key))
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        """Store a value with optional expiration in seconds."""
+        await self._redis.set(key, value, ex=ex)
+
+    async def delete(self, *keys: str) -> int:
+        """Delete one or more keys. Returns number of keys removed."""
+        return cast("int", await self._redis.delete(*keys))
+
+    async def exists(self, *keys: str) -> int:
+        """Return the number of provided keys that exist."""
+        return cast("int", await self._redis.exists(*keys))
+
+    async def ping(self) -> bool:
+        """Return ``True`` if the server responds to PING."""
+        result = self._redis.ping()
+        if isawaitable(result):
+            return bool(await result)
+        return bool(result)
+
+    async def close(self) -> None:
+        """Close the underlying connection pool."""
+        await self._redis.aclose()
+
+    def unwrap(self) -> Redis:
+        """Access the underlying Redis client."""
+        return self._redis
+
+
+def register(registry: CacheRegistry) -> None:
+    """Register the Redis backend in an injected registry."""
+    registry.register("redis", RedisCacheBackend)

--- a/packages/pykit-cache/src/pykit_cache/registry.py
+++ b/packages/pykit-cache/src/pykit_cache/registry.py
@@ -1,0 +1,54 @@
+"""Explicit cache backend registry."""
+
+from __future__ import annotations
+
+from pykit_cache.backends import CacheBackend, CacheFactory, InMemoryCache
+from pykit_cache.config import CacheConfig
+from pykit_errors import AppError
+from pykit_errors.codes import ErrorCode
+
+
+class CacheRegistry:
+    """Injected registry mapping backend names to factories."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, CacheFactory] = {}
+
+    def register(self, name: str, factory: CacheFactory) -> None:
+        """Register a backend factory under ``name``."""
+        if not name:
+            raise AppError(ErrorCode.INVALID_INPUT, "cache backend name is required")
+        self._factories[name] = factory
+
+    def create(self, config: CacheConfig) -> CacheBackend:
+        """Construct the configured backend."""
+        try:
+            factory = self._factories[config.backend]
+        except KeyError as exc:
+            raise AppError(
+                ErrorCode.INVALID_INPUT,
+                f"cache backend '{config.backend}' is not registered",
+            ) from exc
+        return factory(config)
+
+    def names(self) -> tuple[str, ...]:
+        """Return registered backend names."""
+        return tuple(sorted(self._factories))
+
+
+def register_memory(registry: CacheRegistry) -> None:
+    """Register the lean in-memory cache backend."""
+    registry.register(
+        "memory",
+        lambda config: InMemoryCache(
+            default_ttl_seconds=config.default_ttl_seconds,
+            max_entries=config.max_entries,
+        ),
+    )
+
+
+def default_cache_registry() -> CacheRegistry:
+    """Return a new registry containing only lean core defaults."""
+    registry = CacheRegistry()
+    register_memory(registry)
+    return registry

--- a/packages/pykit-cache/tests/test_cache.py
+++ b/packages/pykit-cache/tests/test_cache.py
@@ -7,7 +7,16 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from pykit_cache import CacheClient, CacheComponent, CacheConfig, TypedStore
+from pykit_cache import (
+    CacheClient,
+    CacheComponent,
+    CacheConfig,
+    CacheRegistry,
+    InMemoryCache,
+    TypedStore,
+    default_cache_registry,
+    register_memory,
+)
 from pykit_component import HealthStatus
 from pykit_testutil import FakeAsyncKeyValue
 
@@ -39,6 +48,7 @@ class TestCacheConfig:
     def test_defaults(self) -> None:
         cfg = CacheConfig()
         assert cfg.name == "cache"
+        assert cfg.backend == "memory"
         assert cfg.url == "redis://localhost:6379/0"
         assert cfg.db == 0
         assert cfg.max_connections == 10
@@ -47,6 +57,19 @@ class TestCacheConfig:
         assert cfg.retry_on_timeout is True
         assert cfg.decode_responses is True
         assert cfg.enabled is True
+
+    def test_empty_registry_has_no_side_effect_backends(self) -> None:
+        registry = CacheRegistry()
+        assert registry.names() == ()
+
+    def test_explicit_memory_registration(self) -> None:
+        registry = CacheRegistry()
+        register_memory(registry)
+        assert registry.names() == ("memory",)
+        assert isinstance(registry.create(CacheConfig()), InMemoryCache)
+
+    def test_default_registry_only_contains_memory(self) -> None:
+        assert default_cache_registry().names() == ("memory",)
 
     def test_custom_values(self) -> None:
         cfg = CacheConfig(name="cache", url="redis://remote:6380/2", db=2, max_connections=50)
@@ -76,6 +99,15 @@ class TestCacheClient:
     async def test_set_with_expiry(self, client: CacheClient) -> None:
         await client.set("k1", "v1", ex=60)
         assert await client.get("k1") == "v1"
+
+    async def test_ttl_boundary_expires(self) -> None:
+        client = CacheClient(CacheConfig())
+        await client.set("short", "v", ex=1)
+        assert await client.get("short") == "v"
+        import asyncio
+
+        await asyncio.sleep(1.01)
+        assert await client.get("short") is None
 
     async def test_delete(self, client: CacheClient) -> None:
         await client.set("k1", "v1")

--- a/packages/pykit-cache/tests/test_cache.py
+++ b/packages/pykit-cache/tests/test_cache.py
@@ -20,7 +20,7 @@ from pykit_cache import (
 )
 from pykit_cache.redis import RedisCacheBackend
 from pykit_component import HealthStatus
-from pykit_errors import InvalidInputError
+from pykit_errors import InvalidInputError, ServiceUnavailableError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -256,6 +256,16 @@ class TestCacheComponent:
         comp._client = fake
         # Verify ping works
         assert await fake.ping() is True
+
+    async def test_start_fails_when_backend_ping_returns_false(self) -> None:
+        registry = CacheRegistry()
+        backend = InMemoryCache()
+        await backend.close()
+        registry.register("memory", lambda _config: backend)
+        comp = CacheComponent(CacheConfig(), registry=registry)
+
+        with pytest.raises(ServiceUnavailableError, match="ping failed"):
+            await comp.start()
 
     async def test_health_ping_failure(self) -> None:
         """Cover component.py lines 48-49: health check when ping raises."""

--- a/packages/pykit-cache/tests/test_cache.py
+++ b/packages/pykit-cache/tests/test_cache.py
@@ -18,7 +18,9 @@ from pykit_cache import (
     default_cache_registry,
     register_memory,
 )
+from pykit_cache.redis import RedisCacheBackend
 from pykit_component import HealthStatus
+from pykit_errors import InvalidInputError
 from pykit_testutil import FakeAsyncKeyValue
 
 # ---------------------------------------------------------------------------
@@ -78,6 +80,11 @@ class TestCacheConfig:
         assert cfg.url == "redis://remote:6380/2"
         assert cfg.db == 2
         assert cfg.max_connections == 50
+
+    def test_redis_backend_rejects_byte_responses(self) -> None:
+        cfg = CacheConfig(decode_responses=False)
+        with pytest.raises(InvalidInputError, match="decode_responses=True"):
+            RedisCacheBackend(cfg)
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +244,12 @@ class TestCacheComponent:
         comp = CacheComponent(CacheConfig(enabled=False))
         await comp.start()
         assert comp.client is None
+
+    async def test_disabled_health_is_healthy(self) -> None:
+        comp = CacheComponent(CacheConfig(enabled=False))
+        h = await comp.health()
+        assert h.status == HealthStatus.HEALTHY
+        assert h.message == "cache disabled"
 
     async def test_start_enabled_creates_client(self) -> None:
         """Cover component.py lines 29-30: start with enabled config creates client and pings."""

--- a/packages/pykit-cache/tests/test_cache.py
+++ b/packages/pykit-cache/tests/test_cache.py
@@ -9,6 +9,7 @@ import pytest
 
 import pykit_cache.backends as cache_backends
 from pykit_cache import (
+    CacheBackend,
     CacheClient,
     CacheComponent,
     CacheConfig,
@@ -146,8 +147,8 @@ class TestCacheClient:
         await client.close()
 
     async def test_unwrap(self, client: CacheClient) -> None:
-        raw = client.unwrap()
-        assert raw is not None
+        raw: CacheBackend = client.unwrap()
+        assert await raw.ping() is True
 
 
 # ---------------------------------------------------------------------------

--- a/packages/pykit-cache/tests/test_cache.py
+++ b/packages/pykit-cache/tests/test_cache.py
@@ -21,7 +21,6 @@ from pykit_cache import (
 from pykit_cache.redis import RedisCacheBackend
 from pykit_component import HealthStatus
 from pykit_errors import InvalidInputError
-from pykit_testutil import FakeAsyncKeyValue
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -35,11 +34,9 @@ class _SampleState:
 
 
 def _make_client(config: CacheConfig | None = None) -> CacheClient:
-    """Create a CacheClient backed by pykit-testutil."""
+    """Create a CacheClient backed by the default in-memory backend."""
     cfg = config or CacheConfig()
-    client = CacheClient(cfg)
-    client._redis = FakeAsyncKeyValue(decode_responses=cfg.decode_responses)
-    return client
+    return CacheClient(cfg)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/pykit-cache/tests/test_cache.py
+++ b/packages/pykit-cache/tests/test_cache.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import pykit_cache.backends as cache_backends
 from pykit_cache import (
     CacheClient,
     CacheComponent,
@@ -100,13 +101,14 @@ class TestCacheClient:
         await client.set("k1", "v1", ex=60)
         assert await client.get("k1") == "v1"
 
-    async def test_ttl_boundary_expires(self) -> None:
+    async def test_ttl_boundary_expires(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        now = 1_000.0
+        monkeypatch.setattr(cache_backends.time, "monotonic", lambda: now)
         client = CacheClient(CacheConfig())
         await client.set("short", "v", ex=1)
         assert await client.get("short") == "v"
-        import asyncio
 
-        await asyncio.sleep(1.01)
+        now += 1.01
         assert await client.get("short") is None
 
     async def test_delete(self, client: CacheClient) -> None:

--- a/packages/pykit-cache/tests/test_cache.py
+++ b/packages/pykit-cache/tests/test_cache.py
@@ -266,6 +266,8 @@ class TestCacheComponent:
 
         with pytest.raises(ServiceUnavailableError, match="ping failed"):
             await comp.start()
+        assert comp.client is None
+        assert await backend.ping() is False
 
     async def test_health_ping_failure(self) -> None:
         """Cover component.py lines 48-49: health check when ping raises."""

--- a/packages/pykit-cache/tests/test_cache_extended.py
+++ b/packages/pykit-cache/tests/test_cache_extended.py
@@ -12,7 +12,6 @@ import pytest
 
 from pykit_cache import CacheClient, CacheComponent, CacheConfig, TypedStore
 from pykit_component import HealthStatus
-from pykit_testutil import FakeAsyncKeyValue
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -30,11 +29,9 @@ class _ComplexState:
 
 
 def _make_client(config: CacheConfig | None = None) -> CacheClient:
-    """Create a CacheClient backed by pykit-testutil."""
+    """Create a CacheClient backed by the default in-memory backend."""
     cfg = config or CacheConfig()
-    client = CacheClient(cfg)
-    client._redis = FakeAsyncKeyValue(decode_responses=cfg.decode_responses)
-    return client
+    return CacheClient(cfg)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/pykit-database/README.md
+++ b/packages/pykit-database/README.md
@@ -1,57 +1,66 @@
 # pykit-database
 
-Async SQLAlchemy database toolkit with repository pattern, error translation, and component lifecycle.
+Async database abstraction with SQLAlchemy backend selection, explicit driver extras, repository
+helpers, transaction rollback/cancellation behavior, tenant scoping, and component lifecycle.
 
 ## Installation
 
 ```bash
 pip install pykit-database
-# or
+pip install 'pykit-database[sqlite]'    # aiosqlite driver
+pip install 'pykit-database[postgres]'  # asyncpg driver
+
 uv add pykit-database
+uv add 'pykit-database[sqlite]'    # aiosqlite driver
+uv add 'pykit-database[postgres]'  # asyncpg driver
 ```
 
 ## Quick Start
 
 ```python
-from pykit_database import Database, DatabaseConfig, DatabaseComponent, Repository
+from pykit_database import Database, DatabaseConfig, Repository
 
-# Direct usage
-config = DatabaseConfig(dsn="sqlite+aiosqlite:///app.db", pool_size=5)
-db = Database(config)
+db = Database(DatabaseConfig(dsn="sqlite+aiosqlite:///app.db"))
 
 async with db.session() as session:
     result = await session.execute(select(User).where(User.id == user_id))
     user = result.scalar_one()
 
-# Repository pattern with full CRUD
 repo = Repository(db.session, User)
-user = await repo.create(User(name="Alice", email="alice@example.com"))
-users = await repo.list(offset=0, limit=10, filters={"name": "Alice"})
-await repo.delete(user.id)
-
-# Component lifecycle integration
-component = DatabaseComponent(config)
-await component.start()     # connects and pings
-health = await component.health()  # HEALTHY or UNHEALTHY
-await component.stop()
+created = await repo.create(User(name="Alice", email="alice@example.com"))
 ```
+
+`Database.session()` commits on success and rolls back on exceptions and cancellation.
+
+## Registry and component selection
+
+```python
+from pykit_database import (
+    DatabaseComponent,
+    DatabaseConfig,
+    DatabaseRegistry,
+    register_sqlalchemy,
+)
+
+registry = DatabaseRegistry()
+register_sqlalchemy(registry)
+
+component = DatabaseComponent(
+    DatabaseConfig(backend="sqlalchemy", dsn="postgresql+asyncpg://..."),
+    registry=registry,
+)
+await component.start()
+```
+
+## Tenant isolation
+
+Use `scope_to_tenant()` to apply row-level tenant predicates and `set_session_variable()` for
+PostgreSQL RLS session variables. Tenant IDs must be applied at repository/query boundaries.
 
 ## Key Components
 
-- **DatabaseConfig** — Configuration dataclass with `dsn`, `echo`, `pool_size`, `max_overflow`, `pool_timeout`, `pool_recycle`, and `auto_migrate`
-- **Database** — Async SQLAlchemy wrapper with `session()` context manager (auto-commit/rollback), `execute()`, `ping()`, `close()`, and `run_migrations(metadata)`
-- **Repository[T]** — Generic CRUD repository with `create()`, `get_by_id()`, `list()`, `count()`, `exists()`, `update()`, `delete()`, and `save()` (upsert)
-- **ReadRepository[T]** — Read-only repository with `get_by_id()`, `list()`, `count()`, and `exists()`
-- **DatabaseComponent** — Component protocol implementation with `start()`, `stop()`, and `health()` for managed lifecycle
-- **Error translation** — `translate_error()` maps SQLAlchemy exceptions to pykit `AppError` subtypes (NotFoundError, ServiceUnavailableError, ALREADY_EXISTS, DATABASE_ERROR)
-
-## Dependencies
-
-- `sqlalchemy[asyncio]` — Async SQLAlchemy ORM and core
-- `pykit-errors` — Error types and translation
-- `pykit-component` — Component lifecycle protocol
-
-## See Also
-
-- [Main pykit README](../../README.md)
-- [tests/](tests/) — additional usage examples
+- **DatabaseConfig** — backend, DSN, echo, and bounded pool settings.
+- **DatabaseRegistry** — injected backend registry; empty registries have no backends.
+- **Database** — SQLAlchemy async wrapper with sessions, execute, ping, close, migrations.
+- **Repository[T]** / **ReadRepository[T]** — generic CRUD/read helpers.
+- **tenant helpers** — row-scoped query filtering and PostgreSQL RLS variables.

--- a/packages/pykit-database/pyproject.toml
+++ b/packages/pykit-database/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pykit-database"
-description = "Async database access with SQLAlchemy and asyncpg"
+description = "Async database abstraction with SQLAlchemy backend and explicit driver extras"
 version = "0.1.0"
 readme = "README.md"
 license = { text = "MIT" }
@@ -13,6 +13,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+postgres = ["asyncpg"]
+sqlite = ["aiosqlite"]
 test = ["aiosqlite"]
 
 [build-system]

--- a/packages/pykit-database/src/pykit_database/__init__.py
+++ b/packages/pykit-database/src/pykit_database/__init__.py
@@ -14,6 +14,7 @@ from pykit_database.query import (
     build_paginated_result,
     parse_query_params,
 )
+from pykit_database.registry import DatabaseRegistry, default_database_registry, register_sqlalchemy
 from pykit_database.repository import ReadRepository, Repository
 from pykit_database.tenant import scope_to_tenant, set_session_variable
 
@@ -21,6 +22,7 @@ __all__ = [
     "Database",
     "DatabaseComponent",
     "DatabaseConfig",
+    "DatabaseRegistry",
     "PaginatedResult",
     "Pagination",
     "QueryConfig",
@@ -29,7 +31,9 @@ __all__ = [
     "Repository",
     "apply_to_query",
     "build_paginated_result",
+    "default_database_registry",
     "parse_query_params",
+    "register_sqlalchemy",
     "scope_to_tenant",
     "set_session_variable",
 ]

--- a/packages/pykit-database/src/pykit_database/component.py
+++ b/packages/pykit-database/src/pykit_database/component.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from pykit_component import Component, Health, HealthStatus
 from pykit_database.config import DatabaseConfig
 from pykit_database.database import Database
+from pykit_database.registry import DatabaseRegistry, default_database_registry
 
 
 class DatabaseComponent:
     """Wraps :class:`Database` with :class:`Component` lifecycle semantics."""
 
-    def __init__(self, config: DatabaseConfig) -> None:
+    def __init__(self, config: DatabaseConfig, *, registry: DatabaseRegistry | None = None) -> None:
         self._config = config
+        self._registry = registry or default_database_registry()
         self._database: Database | None = None
 
     # -- Component protocol --------------------------------------------------
@@ -21,7 +23,7 @@ class DatabaseComponent:
         return self._config.name
 
     async def start(self) -> None:
-        self._database = Database(self._config)
+        self._database = self._registry.create(self._config)
         if not await self._database.ping():
             raise RuntimeError(f"database '{self._config.name}' is not reachable")
 

--- a/packages/pykit-database/src/pykit_database/config.py
+++ b/packages/pykit-database/src/pykit_database/config.py
@@ -11,7 +11,7 @@ class DatabaseConfig:
 
     name: str = "database"
     backend: str = "sqlalchemy"
-    dsn: str = "sqlite+aiosqlite:///db.sqlite3"
+    dsn: str = ""
     echo: bool = False
     pool_size: int = 5
     max_overflow: int = 10

--- a/packages/pykit-database/src/pykit_database/config.py
+++ b/packages/pykit-database/src/pykit_database/config.py
@@ -10,6 +10,7 @@ class DatabaseConfig:
     """Configuration for async SQLAlchemy database connections."""
 
     name: str = "database"
+    backend: str = "sqlalchemy"
     dsn: str = "sqlite+aiosqlite:///db.sqlite3"
     echo: bool = False
     pool_size: int = 5

--- a/packages/pykit-database/src/pykit_database/database.py
+++ b/packages/pykit-database/src/pykit_database/database.py
@@ -46,7 +46,7 @@ class Database:
             try:
                 yield sess
                 await sess.commit()
-            except Exception:
+            except BaseException:
                 await sess.rollback()
                 raise
 

--- a/packages/pykit-database/src/pykit_database/database.py
+++ b/packages/pykit-database/src/pykit_database/database.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -50,7 +51,7 @@ class Database:
                 yield sess
                 await sess.commit()
             except BaseException:
-                await sess.rollback()
+                await asyncio.shield(sess.rollback())
                 raise
 
     async def execute(self, stmt: Any) -> Any:

--- a/packages/pykit-database/src/pykit_database/database.py
+++ b/packages/pykit-database/src/pykit_database/database.py
@@ -10,12 +10,15 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 from pykit_database.config import DatabaseConfig
+from pykit_errors import InvalidInputError
 
 
 class Database:
     """Thin wrapper around an async SQLAlchemy engine and session factory."""
 
     def __init__(self, config: DatabaseConfig) -> None:
+        if not config.dsn:
+            raise InvalidInputError("database DSN is required", field="dsn")
         self._config = config
 
         # SQLite does not support pool_size / max_overflow / pool_timeout / pool_recycle

--- a/packages/pykit-database/src/pykit_database/registry.py
+++ b/packages/pykit-database/src/pykit_database/registry.py
@@ -1,0 +1,52 @@
+"""Explicit database backend registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pykit_database.config import DatabaseConfig
+from pykit_database.database import Database
+from pykit_errors import AppError
+from pykit_errors.codes import ErrorCode
+
+DatabaseFactory = Callable[[DatabaseConfig], Database]
+
+
+class DatabaseRegistry:
+    """Injected registry for database backend factories."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, DatabaseFactory] = {}
+
+    def register(self, name: str, factory: DatabaseFactory) -> None:
+        """Register a database backend factory."""
+        if not name:
+            raise AppError(ErrorCode.INVALID_INPUT, "database backend name is required")
+        self._factories[name] = factory
+
+    def create(self, config: DatabaseConfig) -> Database:
+        """Construct the configured database backend."""
+        try:
+            factory = self._factories[config.backend]
+        except KeyError as exc:
+            raise AppError(
+                ErrorCode.INVALID_INPUT,
+                f"database backend '{config.backend}' is not registered",
+            ) from exc
+        return factory(config)
+
+    def names(self) -> tuple[str, ...]:
+        """Return registered backend names."""
+        return tuple(sorted(self._factories))
+
+
+def register_sqlalchemy(registry: DatabaseRegistry) -> None:
+    """Register the SQLAlchemy async backend."""
+    registry.register("sqlalchemy", Database)
+
+
+def default_database_registry() -> DatabaseRegistry:
+    """Return a new registry containing the SQLAlchemy abstraction backend."""
+    registry = DatabaseRegistry()
+    register_sqlalchemy(registry)
+    return registry

--- a/packages/pykit-database/tests/test_database.py
+++ b/packages/pykit-database/tests/test_database.py
@@ -178,6 +178,33 @@ class TestDatabase:
             assert result.scalars().first() is None
         await database.close()
 
+    async def test_session_rollback_is_shielded(self):
+        config = DatabaseConfig(dsn=IN_MEMORY_DSN)
+        database = Database(config)
+        await database.run_migrations(Base.metadata)
+
+        original_shield = asyncio.shield
+        shielded = False
+
+        async def shield_spy(awaitable):
+            nonlocal shielded
+            shielded = True
+            return await original_shield(awaitable)
+
+        from unittest.mock import patch as _patch
+
+        with (
+            _patch("pykit_database.database.asyncio.shield", side_effect=shield_spy),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            async with database.session() as sess:
+                sess.add(User(name="Shielded", email="shielded@x.com"))
+                await sess.flush()
+                raise asyncio.CancelledError
+
+        assert shielded is True
+        await database.close()
+
     async def test_ping_returns_false_on_failure(self):
         """Cover database.py lines 65-66: ping returns False when exception occurs."""
         config = DatabaseConfig(dsn=IN_MEMORY_DSN)

--- a/packages/pykit-database/tests/test_database.py
+++ b/packages/pykit-database/tests/test_database.py
@@ -162,11 +162,14 @@ class TestDatabase:
         database = Database(config)
         await database.run_migrations(Base.metadata)
 
-        with pytest.raises(asyncio.CancelledError):
+        async def insert_then_cancel() -> None:
             async with database.session() as sess:
                 sess.add(User(name="Cancelled", email="cancelled@x.com"))
                 await sess.flush()
                 raise asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            await insert_then_cancel()
 
         from sqlalchemy import select
 

--- a/packages/pykit-database/tests/test_database.py
+++ b/packages/pykit-database/tests/test_database.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,6 +20,7 @@ from pykit_database.errors import (
     is_not_found_error,
     translate_error,
 )
+from pykit_database.registry import DatabaseRegistry, default_database_registry, register_sqlalchemy
 from pykit_database.repository import ReadRepository, Repository
 from pykit_errors import AppError, NotFoundError, ServiceUnavailableError
 
@@ -77,6 +79,7 @@ class TestDatabaseConfig:
     def test_defaults(self):
         cfg = DatabaseConfig()
         assert cfg.name == "database"
+        assert cfg.backend == "sqlalchemy"
         assert cfg.dsn == "sqlite+aiosqlite:///db.sqlite3"
         assert cfg.echo is False
         assert cfg.pool_size == 5
@@ -84,6 +87,18 @@ class TestDatabaseConfig:
         assert cfg.pool_timeout == 30.0
         assert cfg.pool_recycle == 3600
         assert cfg.auto_migrate is False
+
+    def test_empty_registry_has_no_side_effect_backends(self):
+        registry = DatabaseRegistry()
+        assert registry.names() == ()
+
+    def test_explicit_sqlalchemy_registration(self):
+        registry = DatabaseRegistry()
+        register_sqlalchemy(registry)
+        assert registry.names() == ("sqlalchemy",)
+
+    def test_default_registry_contains_sqlalchemy(self):
+        assert default_database_registry().names() == ("sqlalchemy",)
 
     def test_custom_values(self):
         cfg = DatabaseConfig(name="mydb", dsn="postgresql+asyncpg://localhost/test", echo=True)
@@ -139,6 +154,24 @@ class TestDatabase:
 
         async with database.session() as sess:
             result = await sess.execute(select(User).where(User.email == "ghost@x.com"))
+            assert result.scalars().first() is None
+        await database.close()
+
+    async def test_session_rollback_on_cancellation(self):
+        config = DatabaseConfig(dsn=IN_MEMORY_DSN)
+        database = Database(config)
+        await database.run_migrations(Base.metadata)
+
+        with pytest.raises(asyncio.CancelledError):
+            async with database.session() as sess:
+                sess.add(User(name="Cancelled", email="cancelled@x.com"))
+                await sess.flush()
+                raise asyncio.CancelledError
+
+        from sqlalchemy import select
+
+        async with database.session() as sess:
+            result = await sess.execute(select(User).where(User.email == "cancelled@x.com"))
             assert result.scalars().first() is None
         await database.close()
 

--- a/packages/pykit-database/tests/test_database.py
+++ b/packages/pykit-database/tests/test_database.py
@@ -80,7 +80,7 @@ class TestDatabaseConfig:
         cfg = DatabaseConfig()
         assert cfg.name == "database"
         assert cfg.backend == "sqlalchemy"
-        assert cfg.dsn == "sqlite+aiosqlite:///db.sqlite3"
+        assert cfg.dsn == ""
         assert cfg.echo is False
         assert cfg.pool_size == 5
         assert cfg.max_overflow == 10

--- a/packages/pykit-database/tests/test_database.py
+++ b/packages/pykit-database/tests/test_database.py
@@ -195,12 +195,12 @@ class TestDatabase:
 
         with (
             _patch("pykit_database.database.asyncio.shield", side_effect=shield_spy),
-            pytest.raises(asyncio.CancelledError),
+            pytest.raises(RuntimeError, match="forced rollback"),
         ):
             async with database.session() as sess:
                 sess.add(User(name="Shielded", email="shielded@x.com"))
                 await sess.flush()
-                raise asyncio.CancelledError
+                raise RuntimeError("forced rollback")
 
         assert shielded is True
         await database.close()

--- a/packages/pykit-observability/src/pykit_observability/prometheus.py
+++ b/packages/pykit-observability/src/pykit_observability/prometheus.py
@@ -1,4 +1,4 @@
-"""Prometheus metrics helpers for gRPC services."""
+"""Prometheus metrics helpers for services and message processing."""
 
 from __future__ import annotations
 

--- a/packages/pykit-storage/README.md
+++ b/packages/pykit-storage/README.md
@@ -1,58 +1,58 @@
 # pykit-storage
 
-Async object-storage abstraction with pluggable backends for local filesystem and S3.
+Async object-storage abstraction with local filesystem lean default and an optional S3 adapter.
+Backends are selected from an injected registry; importing core has no adapter side effects.
 
 ## Installation
 
 ```bash
 pip install pykit-storage
-# or
-uv add pykit-storage
+pip install 'pykit-storage[s3]'  # optional S3 adapter
 
-# With S3 support
-pip install pykit-storage[s3]
+uv add pykit-storage
+uv add 'pykit-storage[s3]'  # optional S3 adapter
 ```
 
-## Quick Start
+## Local Quick Start
 
 ```python
-from pykit_storage import StorageConfig, StorageComponent
+from pykit_storage import StorageComponent, StorageConfig
 
-# Local filesystem storage
-config = StorageConfig(provider="local", base_path="./uploads", public_url="/files")
-component = StorageComponent(config)
+component = StorageComponent(StorageConfig(provider="local", base_path="./uploads"))
 await component.start()
 
 storage = component.storage
 await storage.upload("images/photo.jpg", image_bytes)
-exists = await storage.exists("images/photo.jpg")     # True
-data = await storage.download("images/photo.jpg")      # bytes
-url = await storage.url("images/photo.jpg")            # "/files/images/photo.jpg"
-
-files = await storage.list(prefix="images/")           # [FileInfo(...), ...]
-for f in files:
-    print(f"{f.path} — {f.size} bytes, {f.content_type}")
-
-await storage.delete("images/photo.jpg")
-health = await component.health()
-await component.stop()
+data = await storage.download("images/photo.jpg")
+files = await storage.list("images")
 ```
+
+Local paths are normalized relative paths; absolute paths, traversal (`..`), empty paths, and NUL
+bytes are rejected before filesystem access.
+
+## Explicit S3 registration
+
+```python
+from pykit_storage import StorageComponent, StorageConfig, StorageRegistry, register_local
+from pykit_storage.s3 import register as register_s3
+
+registry = StorageRegistry()
+register_local(registry)
+register_s3(registry)
+
+component = StorageComponent(
+    StorageConfig(provider="s3", bucket="app-objects", region="us-east-1"),
+    registry=registry,
+)
+await component.start()
+```
+
+The S3 adapter uses `aioboto3`, validates object keys, supports upload/download/delete/list,
+`s3://` URLs, and bounded presigned GET URLs.
 
 ## Key Components
 
-- **Storage** — Protocol defining the async storage interface: `upload`, `download`, `delete`, `exists`, `list`, `url`
-- **FileInfo** — Frozen dataclass with file metadata: `path`, `size`, `last_modified`, `content_type`
-- **LocalStorage** — Local filesystem implementation using `aiofiles`
-- **StorageConfig** — Configuration: `provider` ("local" or "s3"), `base_path`, `max_file_size`, `public_url`, `allowed_types`
-- **StorageComponent** — Lifecycle-managed component with `start()`, `stop()`, `health()` (implements Component protocol)
-
-## Dependencies
-
-- `pykit-errors`, `pykit-component`
-- `aiofiles`
-- Optional: `aioboto3` (s3 extra)
-
-## See Also
-
-- [Main pykit README](../../README.md)
-- [tests/](tests/) — additional usage examples
+- **Storage** — async protocol: `upload`, `download`, `delete`, `exists`, `list`, `url`.
+- **StorageRegistry** — injected backend registry; empty registries have no backends.
+- **LocalStorage** — local filesystem default using `aiofiles`.
+- **S3Storage** — optional adapter in `pykit_storage.s3`, registered explicitly.

--- a/packages/pykit-storage/src/pykit_storage/__init__.py
+++ b/packages/pykit-storage/src/pykit_storage/__init__.py
@@ -6,6 +6,7 @@ from pykit_storage.base import FileInfo, SignedURLProvider, Storage
 from pykit_storage.component import StorageComponent
 from pykit_storage.config import StorageConfig
 from pykit_storage.local import LocalStorage
+from pykit_storage.registry import StorageRegistry, default_storage_registry, register_local
 
 __all__ = [
     "FileInfo",
@@ -14,4 +15,7 @@ __all__ = [
     "Storage",
     "StorageComponent",
     "StorageConfig",
+    "StorageRegistry",
+    "default_storage_registry",
+    "register_local",
 ]

--- a/packages/pykit-storage/src/pykit_storage/component.py
+++ b/packages/pykit-storage/src/pykit_storage/component.py
@@ -39,6 +39,8 @@ class StorageComponent:
         self._storage = None
 
     async def health(self) -> Health:
+        if not self._config.enabled:
+            return Health(name=self.name, status=HealthStatus.HEALTHY, message="storage disabled")
         if self._storage is None:
             return Health(name=self.name, status=HealthStatus.UNHEALTHY, message="storage not started")
         return Health(name=self.name, status=HealthStatus.HEALTHY)

--- a/packages/pykit-storage/src/pykit_storage/component.py
+++ b/packages/pykit-storage/src/pykit_storage/component.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 from pykit_component import Health, HealthStatus
 from pykit_storage.base import Storage
 from pykit_storage.config import StorageConfig
-from pykit_storage.local import LocalStorage
+from pykit_storage.registry import StorageRegistry, default_storage_registry
 
 
 class StorageComponent:
     """Lifecycle-managed storage component."""
 
-    def __init__(self, config: StorageConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: StorageConfig | None = None,
+        *,
+        registry: StorageRegistry | None = None,
+    ) -> None:
         self._config = config or StorageConfig()
+        self._registry = registry or default_storage_registry()
         self._storage: Storage | None = None
 
     @property
@@ -24,17 +30,10 @@ class StorageComponent:
         return self._storage
 
     async def start(self) -> None:
-        if self._config.provider == "local":
-            self._storage = LocalStorage(
-                base_path=self._config.base_path,
-                public_url=self._config.public_url,
-            )
-        elif self._config.provider == "s3":
-            msg = "S3 provider requires the 's3' extra: pip install pykit-storage[s3]"
-            raise NotImplementedError(msg)
-        else:
-            msg = f"Unknown storage provider: {self._config.provider}"
-            raise ValueError(msg)
+        """Construct the configured storage backend."""
+        if not self._config.enabled:
+            return
+        self._storage = self._registry.create(self._config)
 
     async def stop(self) -> None:
         self._storage = None

--- a/packages/pykit-storage/src/pykit_storage/config.py
+++ b/packages/pykit-storage/src/pykit_storage/config.py
@@ -16,3 +16,9 @@ class StorageConfig:
     max_file_size: int = 104_857_600  # 100 MB
     public_url: str = ""
     allowed_types: list[str] = field(default_factory=list)
+    bucket: str = ""
+    region: str | None = None
+    endpoint_url: str | None = None
+    access_key_id: str | None = None
+    secret_access_key: str | None = None
+    signed_url_max_seconds: int = 3600

--- a/packages/pykit-storage/src/pykit_storage/local.py
+++ b/packages/pykit-storage/src/pykit_storage/local.py
@@ -88,6 +88,8 @@ class LocalStorage:
         return await asyncio.to_thread(_list_sync)
 
     async def url(self, path: str) -> str:
+        full = self._resolve(path)
         if self._public_url:
-            return f"{self._public_url}/{path}"
-        return self._resolve(path)
+            relative = Path(full).relative_to(self._base_path).as_posix()
+            return f"{self._public_url}/{relative}"
+        return full

--- a/packages/pykit-storage/src/pykit_storage/local.py
+++ b/packages/pykit-storage/src/pykit_storage/local.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 import os
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import BinaryIO, cast
 
 import aiofiles
 import aiofiles.os
 
+from pykit_errors import InvalidInputError
 from pykit_storage.base import FileInfo
 
 
@@ -17,11 +19,23 @@ class LocalStorage:
     """Storage implementation backed by the local filesystem."""
 
     def __init__(self, base_path: str, public_url: str = "") -> None:
-        self._base_path = base_path
+        self._base_path = str(Path(base_path).resolve())
         self._public_url = public_url.rstrip("/")
 
-    def _resolve(self, path: str) -> str:
-        return os.path.join(self._base_path, path)
+    def _resolve(self, path: str, *, allow_empty: bool = False) -> str:
+        if allow_empty and path == "":
+            return self._base_path
+        if path == "" or "\x00" in path:
+            raise InvalidInputError(
+                "storage path must be non-empty and must not contain NUL bytes", field="path"
+            )
+        if Path(path).is_absolute():
+            raise InvalidInputError("storage path must be relative", field="path")
+        resolved = (Path(self._base_path) / path).resolve()
+        base = Path(self._base_path)
+        if resolved != base and base not in resolved.parents:
+            raise InvalidInputError("storage path escapes base path", field="path")
+        return str(resolved)
 
     async def upload(self, path: str, data: bytes | BinaryIO) -> None:
         full = self._resolve(path)
@@ -48,7 +62,7 @@ class LocalStorage:
         return bool(await aiofiles.os.path.exists(self._resolve(path)))
 
     async def list(self, prefix: str = "") -> list[FileInfo]:
-        root = self._resolve(prefix)
+        root = self._resolve(prefix, allow_empty=True)
         if not await aiofiles.os.path.isdir(root):
             return []
 

--- a/packages/pykit-storage/src/pykit_storage/local.py
+++ b/packages/pykit-storage/src/pykit_storage/local.py
@@ -31,6 +31,8 @@ class LocalStorage:
             )
         if Path(path).is_absolute():
             raise InvalidInputError("storage path must be relative", field="path")
+        if any(part in {".", ".."} for part in Path(path).parts):
+            raise InvalidInputError("storage path must be a normalized relative path", field="path")
         resolved = (Path(self._base_path) / path).resolve()
         base = Path(self._base_path)
         if resolved != base and base not in resolved.parents:

--- a/packages/pykit-storage/src/pykit_storage/registry.py
+++ b/packages/pykit-storage/src/pykit_storage/registry.py
@@ -1,0 +1,56 @@
+"""Explicit storage backend registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pykit_errors import AppError
+from pykit_errors.codes import ErrorCode
+from pykit_storage.base import Storage
+from pykit_storage.config import StorageConfig
+from pykit_storage.local import LocalStorage
+
+StorageFactory = Callable[[StorageConfig], Storage]
+
+
+class StorageRegistry:
+    """Injected storage backend registry."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, StorageFactory] = {}
+
+    def register(self, name: str, factory: StorageFactory) -> None:
+        """Register a storage backend factory."""
+        if not name:
+            raise AppError(ErrorCode.INVALID_INPUT, "storage provider name is required")
+        self._factories[name] = factory
+
+    def create(self, config: StorageConfig) -> Storage:
+        """Construct the configured storage backend."""
+        try:
+            factory = self._factories[config.provider]
+        except KeyError as exc:
+            raise AppError(
+                ErrorCode.INVALID_INPUT,
+                f"storage provider '{config.provider}' is not registered",
+            ) from exc
+        return factory(config)
+
+    def names(self) -> tuple[str, ...]:
+        """Return registered backend names."""
+        return tuple(sorted(self._factories))
+
+
+def register_local(registry: StorageRegistry) -> None:
+    """Register local filesystem storage."""
+    registry.register(
+        "local",
+        lambda config: LocalStorage(base_path=config.base_path, public_url=config.public_url),
+    )
+
+
+def default_storage_registry() -> StorageRegistry:
+    """Return a new registry containing only lean core defaults."""
+    registry = StorageRegistry()
+    register_local(registry)
+    return registry

--- a/packages/pykit-storage/src/pykit_storage/s3.py
+++ b/packages/pykit-storage/src/pykit_storage/s3.py
@@ -56,6 +56,11 @@ class S3Storage:
                 response = await client.get_object(Bucket=self._bucket, Key=key)
             except client.exceptions.NoSuchKey as exc:
                 raise NotFoundError("file", key) from exc
+            except client.exceptions.ClientError as exc:
+                error = exc.response.get("Error", {})
+                if error.get("Code") in {"404", "NoSuchKey", "NotFound"}:
+                    raise NotFoundError("file", key) from exc
+                raise AppError(ErrorCode.EXTERNAL_SERVICE, "S3 get_object failed").with_cause(exc) from exc
             body = response["Body"]
             return bytes(await body.read())
 

--- a/packages/pykit-storage/src/pykit_storage/s3.py
+++ b/packages/pykit-storage/src/pykit_storage/s3.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 from datetime import UTC, datetime, timedelta
+from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 from pykit_errors import AppError, InvalidInputError, NotFoundError
@@ -110,13 +111,14 @@ class S3Storage:
         if seconds <= 0 or seconds > self._signed_url_max_seconds:
             raise InvalidInputError("signed URL expiry is out of bounds", field="expiry")
         async with self._client() as client:
-            return str(
-                await client.generate_presigned_url(
-                    "get_object",
-                    Params={"Bucket": self._bucket, "Key": _validate_key(path)},
-                    ExpiresIn=seconds,
-                )
+            url = client.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": self._bucket, "Key": _validate_key(path)},
+                ExpiresIn=seconds,
             )
+            if isawaitable(url):
+                url = await url
+            return str(url)
 
     def _client(self) -> Any:
         return self._session.client("s3", endpoint_url=self._endpoint_url)

--- a/packages/pykit-storage/src/pykit_storage/s3.py
+++ b/packages/pykit-storage/src/pykit_storage/s3.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 from datetime import UTC, datetime, timedelta
 from inspect import isawaitable
-from typing import TYPE_CHECKING, Any, BinaryIO
+from typing import TYPE_CHECKING, Any, BinaryIO, cast
 
 from pykit_errors import AppError, InvalidInputError, NotFoundError
 from pykit_errors.codes import ErrorCode
@@ -53,13 +53,13 @@ class S3Storage:
         """Download an object from S3."""
         key = validate_key(path)
         async with self._client() as client:
+            client_error = _client_error_type()
             try:
                 response = await client.get_object(Bucket=self._bucket, Key=key)
             except client.exceptions.NoSuchKey as exc:
                 raise NotFoundError("file", key) from exc
-            except client.exceptions.ClientError as exc:
-                error = exc.response.get("Error", {})
-                if error.get("Code") in {"404", "NoSuchKey", "NotFound"}:
+            except client_error as exc:
+                if _client_error_code(exc) in {"404", "NoSuchKey", "NotFound"}:
                     raise NotFoundError("file", key) from exc
                 raise AppError(ErrorCode.EXTERNAL_SERVICE, "S3 get_object failed").with_cause(exc) from exc
             body = response["Body"]
@@ -75,13 +75,13 @@ class S3Storage:
         """Return whether an object exists."""
         key = validate_key(path)
         async with self._client() as client:
+            client_error = _client_error_type()
             try:
                 await client.head_object(Bucket=self._bucket, Key=key)
             except client.exceptions.NoSuchKey:
                 return False
-            except client.exceptions.ClientError as exc:
-                error = exc.response.get("Error", {})
-                if error.get("Code") in {"404", "NoSuchKey", "NotFound"}:
+            except client_error as exc:
+                if _client_error_code(exc) in {"404", "NoSuchKey", "NotFound"}:
                     return False
                 raise AppError(ErrorCode.EXTERNAL_SERVICE, "S3 head_object failed").with_cause(exc) from exc
             return True
@@ -137,6 +137,21 @@ def validate_key(path: str) -> str:
     if path.startswith("/") or any(part in {"", ".", ".."} for part in path.split("/")):
         raise InvalidInputError("storage key must be a normalized relative path", field="path")
     return path
+
+
+def _client_error_type() -> type[Exception]:
+    return cast("type[Exception]", importlib.import_module("botocore.exceptions").ClientError)
+
+
+def _client_error_code(exc: BaseException) -> str | None:
+    response = getattr(exc, "response", None)
+    if not isinstance(response, dict):
+        return None
+    error = response.get("Error")
+    if not isinstance(error, dict):
+        return None
+    code = error.get("Code")
+    return str(code) if code is not None else None
 
 
 def register(registry: StorageRegistry) -> None:

--- a/packages/pykit-storage/src/pykit_storage/s3.py
+++ b/packages/pykit-storage/src/pykit_storage/s3.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import importlib
 from datetime import UTC, datetime, timedelta
 from inspect import isawaitable
@@ -43,14 +42,16 @@ class S3Storage:
 
     async def upload(self, path: str, data: bytes | BinaryIO) -> None:
         """Upload bytes or a binary stream to S3."""
-        key = _validate_key(path)
-        raw = data if isinstance(data, bytes) else await asyncio.to_thread(data.read)
+        key = validate_key(path)
         async with self._client() as client:
-            await client.put_object(Bucket=self._bucket, Key=key, Body=raw)
+            if isinstance(data, bytes):
+                await client.put_object(Bucket=self._bucket, Key=key, Body=data)
+            else:
+                await client.upload_fileobj(data, self._bucket, key)
 
     async def download(self, path: str) -> bytes:
         """Download an object from S3."""
-        key = _validate_key(path)
+        key = validate_key(path)
         async with self._client() as client:
             try:
                 response = await client.get_object(Bucket=self._bucket, Key=key)
@@ -66,13 +67,13 @@ class S3Storage:
 
     async def delete(self, path: str) -> None:
         """Delete an object from S3."""
-        key = _validate_key(path)
+        key = validate_key(path)
         async with self._client() as client:
             await client.delete_object(Bucket=self._bucket, Key=key)
 
     async def exists(self, path: str) -> bool:
         """Return whether an object exists."""
-        key = _validate_key(path)
+        key = validate_key(path)
         async with self._client() as client:
             try:
                 await client.head_object(Bucket=self._bucket, Key=key)
@@ -87,7 +88,7 @@ class S3Storage:
 
     async def list(self, prefix: str = "") -> list[FileInfo]:
         """List object metadata under a prefix."""
-        safe_prefix = "" if prefix == "" else f"{_validate_key(prefix.rstrip('/'))}/"
+        safe_prefix = "" if prefix == "" else f"{validate_key(prefix.rstrip('/'))}/"
         items: list[FileInfo] = []
         async with self._client() as client:
             paginator = client.get_paginator("list_objects_v2")
@@ -108,7 +109,7 @@ class S3Storage:
 
     async def url(self, path: str) -> str:
         """Return an s3:// URL for the object."""
-        return f"s3://{self._bucket}/{_validate_key(path)}"
+        return f"s3://{self._bucket}/{validate_key(path)}"
 
     async def signed_url(self, path: str, expiry: timedelta) -> str:
         """Create a bounded presigned GET URL."""
@@ -118,7 +119,7 @@ class S3Storage:
         async with self._client() as client:
             url = client.generate_presigned_url(
                 "get_object",
-                Params={"Bucket": self._bucket, "Key": _validate_key(path)},
+                Params={"Bucket": self._bucket, "Key": validate_key(path)},
                 ExpiresIn=seconds,
             )
             if isawaitable(url):
@@ -129,7 +130,8 @@ class S3Storage:
         return self._session.client("s3", endpoint_url=self._endpoint_url)
 
 
-def _validate_key(path: str) -> str:
+def validate_key(path: str) -> str:
+    """Validate and return a normalized S3 object key."""
     if path == "" or "\x00" in path:
         raise InvalidInputError("storage key must be non-empty and must not contain NUL bytes", field="path")
     if path.startswith("/") or any(part in {"", ".", ".."} for part in path.split("/")):

--- a/packages/pykit-storage/src/pykit_storage/s3.py
+++ b/packages/pykit-storage/src/pykit_storage/s3.py
@@ -82,7 +82,7 @@ class S3Storage:
 
     async def list(self, prefix: str = "") -> list[FileInfo]:
         """List object metadata under a prefix."""
-        safe_prefix = "" if prefix == "" else _validate_key(prefix.rstrip("/") + "/")
+        safe_prefix = "" if prefix == "" else f"{_validate_key(prefix.rstrip('/'))}/"
         items: list[FileInfo] = []
         async with self._client() as client:
             paginator = client.get_paginator("list_objects_v2")

--- a/packages/pykit-storage/src/pykit_storage/s3.py
+++ b/packages/pykit-storage/src/pykit_storage/s3.py
@@ -1,0 +1,135 @@
+"""Optional S3 storage adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, BinaryIO
+
+from pykit_errors import AppError, InvalidInputError, NotFoundError
+from pykit_errors.codes import ErrorCode
+from pykit_storage.base import FileInfo
+from pykit_storage.config import StorageConfig
+
+if TYPE_CHECKING:
+    from pykit_storage.registry import StorageRegistry
+
+
+class S3Storage:
+    """S3 object storage backend requiring explicit registration."""
+
+    def __init__(self, config: StorageConfig) -> None:
+        if not config.bucket:
+            raise InvalidInputError("S3 bucket is required", field="bucket")
+        try:
+            aioboto3 = importlib.import_module("aioboto3")
+        except ImportError as exc:
+            msg = "aioboto3 is required for S3Storage; install pykit-storage[s3]"
+            raise ImportError(msg) from exc
+
+        kwargs: dict[str, str] = {}
+        if config.region:
+            kwargs["region_name"] = config.region
+        if config.access_key_id:
+            kwargs["aws_access_key_id"] = config.access_key_id
+        if config.secret_access_key:
+            kwargs["aws_secret_access_key"] = config.secret_access_key
+        self._session = aioboto3.Session(**kwargs)
+        self._bucket = config.bucket
+        self._endpoint_url = config.endpoint_url
+        self._signed_url_max_seconds = config.signed_url_max_seconds
+
+    async def upload(self, path: str, data: bytes | BinaryIO) -> None:
+        """Upload bytes or a binary stream to S3."""
+        key = _validate_key(path)
+        raw = data if isinstance(data, bytes) else await asyncio.to_thread(data.read)
+        async with self._client() as client:
+            await client.put_object(Bucket=self._bucket, Key=key, Body=raw)
+
+    async def download(self, path: str) -> bytes:
+        """Download an object from S3."""
+        key = _validate_key(path)
+        async with self._client() as client:
+            try:
+                response = await client.get_object(Bucket=self._bucket, Key=key)
+            except client.exceptions.NoSuchKey as exc:
+                raise NotFoundError("file", key) from exc
+            body = response["Body"]
+            return bytes(await body.read())
+
+    async def delete(self, path: str) -> None:
+        """Delete an object from S3."""
+        key = _validate_key(path)
+        async with self._client() as client:
+            await client.delete_object(Bucket=self._bucket, Key=key)
+
+    async def exists(self, path: str) -> bool:
+        """Return whether an object exists."""
+        key = _validate_key(path)
+        async with self._client() as client:
+            try:
+                await client.head_object(Bucket=self._bucket, Key=key)
+            except client.exceptions.NoSuchKey:
+                return False
+            except client.exceptions.ClientError as exc:
+                error = exc.response.get("Error", {})
+                if error.get("Code") in {"404", "NoSuchKey", "NotFound"}:
+                    return False
+                raise AppError(ErrorCode.EXTERNAL_SERVICE, "S3 head_object failed").with_cause(exc) from exc
+            return True
+
+    async def list(self, prefix: str = "") -> list[FileInfo]:
+        """List object metadata under a prefix."""
+        safe_prefix = "" if prefix == "" else _validate_key(prefix.rstrip("/") + "/")
+        items: list[FileInfo] = []
+        async with self._client() as client:
+            paginator = client.get_paginator("list_objects_v2")
+            async for page in paginator.paginate(Bucket=self._bucket, Prefix=safe_prefix):
+                for obj in page.get("Contents", []):
+                    modified = obj.get("LastModified")
+                    items.append(
+                        FileInfo(
+                            path=str(obj["Key"]),
+                            size=int(obj.get("Size", 0)),
+                            last_modified=modified
+                            if isinstance(modified, datetime)
+                            else datetime.now(tz=UTC),
+                            content_type="application/octet-stream",
+                        )
+                    )
+        return items
+
+    async def url(self, path: str) -> str:
+        """Return an s3:// URL for the object."""
+        return f"s3://{self._bucket}/{_validate_key(path)}"
+
+    async def signed_url(self, path: str, expiry: timedelta) -> str:
+        """Create a bounded presigned GET URL."""
+        seconds = int(expiry.total_seconds())
+        if seconds <= 0 or seconds > self._signed_url_max_seconds:
+            raise InvalidInputError("signed URL expiry is out of bounds", field="expiry")
+        async with self._client() as client:
+            return str(
+                await client.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": self._bucket, "Key": _validate_key(path)},
+                    ExpiresIn=seconds,
+                )
+            )
+
+    def _client(self) -> Any:
+        return self._session.client("s3", endpoint_url=self._endpoint_url)
+
+
+def _validate_key(path: str) -> str:
+    if path == "" or "\x00" in path:
+        raise InvalidInputError("storage key must be non-empty and must not contain NUL bytes", field="path")
+    if path.startswith("/") or any(part in {"", ".", ".."} for part in path.split("/")):
+        raise InvalidInputError("storage key must be a normalized relative path", field="path")
+    return path
+
+
+def register(registry: StorageRegistry) -> None:
+    """Register the S3 backend in an injected registry."""
+    registry.register("s3", S3Storage)

--- a/packages/pykit-storage/tests/test_storage.py
+++ b/packages/pykit-storage/tests/test_storage.py
@@ -8,7 +8,16 @@ import pytest
 
 from pykit_component import HealthStatus
 from pykit_errors import NotFoundError
-from pykit_storage import FileInfo, LocalStorage, Storage, StorageComponent, StorageConfig
+from pykit_storage import (
+    FileInfo,
+    LocalStorage,
+    Storage,
+    StorageComponent,
+    StorageConfig,
+    StorageRegistry,
+    default_storage_registry,
+    register_local,
+)
 
 # ---------------------------------------------------------------------------
 # Config
@@ -25,6 +34,20 @@ class TestStorageConfig:
         assert cfg.max_file_size == 104_857_600
         assert cfg.public_url == ""
         assert cfg.allowed_types == []
+        assert cfg.bucket == ""
+
+    def test_empty_registry_has_no_side_effect_backends(self) -> None:
+        registry = StorageRegistry()
+        assert registry.names() == ()
+
+    def test_explicit_local_registration(self, tmp_path: Path) -> None:
+        registry = StorageRegistry()
+        register_local(registry)
+        storage = registry.create(StorageConfig(base_path=str(tmp_path)))
+        assert isinstance(storage, LocalStorage)
+
+    def test_default_registry_only_contains_local(self) -> None:
+        assert default_storage_registry().names() == ("local",)
 
 
 # ---------------------------------------------------------------------------
@@ -132,12 +155,12 @@ class TestStorageComponent:
 
     async def test_unknown_provider_raises(self) -> None:
         comp = StorageComponent(StorageConfig(provider="gcs"))
-        with pytest.raises(ValueError, match="Unknown storage provider"):
+        with pytest.raises(Exception, match="not registered"):
             await comp.start()
 
-    async def test_s3_provider_raises_not_implemented(self) -> None:
+    async def test_s3_provider_requires_explicit_registration(self) -> None:
         comp = StorageComponent(StorageConfig(provider="s3"))
-        with pytest.raises(NotImplementedError, match="S3 provider"):
+        with pytest.raises(Exception, match="not registered"):
             await comp.start()
 
     async def test_roundtrip_through_component(self, tmp_path: Path) -> None:

--- a/packages/pykit-storage/tests/test_storage.py
+++ b/packages/pykit-storage/tests/test_storage.py
@@ -149,6 +149,13 @@ class TestStorageComponent:
         h = await comp.health()
         assert h.status == HealthStatus.UNHEALTHY
 
+    async def test_disabled_health_is_healthy(self) -> None:
+        comp = StorageComponent(StorageConfig(enabled=False))
+        await comp.start()
+        h = await comp.health()
+        assert h.status == HealthStatus.HEALTHY
+        assert h.message == "storage disabled"
+
     async def test_name(self) -> None:
         comp = StorageComponent(StorageConfig(name="my-storage"))
         assert comp.name == "my-storage"

--- a/packages/pykit-storage/tests/test_storage.py
+++ b/packages/pykit-storage/tests/test_storage.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from pykit_component import HealthStatus
-from pykit_errors import NotFoundError
+from pykit_errors import AppError, NotFoundError
 from pykit_storage import (
     FileInfo,
     LocalStorage,
@@ -155,12 +155,12 @@ class TestStorageComponent:
 
     async def test_unknown_provider_raises(self) -> None:
         comp = StorageComponent(StorageConfig(provider="gcs"))
-        with pytest.raises(Exception, match="not registered"):
+        with pytest.raises(AppError, match="not registered"):
             await comp.start()
 
     async def test_s3_provider_requires_explicit_registration(self) -> None:
         comp = StorageComponent(StorageConfig(provider="s3"))
-        with pytest.raises(Exception, match="not registered"):
+        with pytest.raises(AppError, match="not registered"):
             await comp.start()
 
     async def test_roundtrip_through_component(self, tmp_path: Path) -> None:

--- a/packages/pykit-storage/tests/test_storage_extended.py
+++ b/packages/pykit-storage/tests/test_storage_extended.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from pykit_errors import InvalidInputError
 from pykit_storage import FileInfo, LocalStorage, StorageConfig
 from pykit_storage.s3 import _validate_key
 
@@ -55,11 +56,11 @@ class TestPathTraversalSecurity:
 
 class TestS3ConfigValidation:
     def test_s3_key_rejects_path_traversal(self) -> None:
-        with pytest.raises(Exception, match="normalized relative"):
+        with pytest.raises(InvalidInputError, match="normalized relative"):
             _validate_key("../secret")
 
     def test_s3_key_rejects_absolute_paths(self) -> None:
-        with pytest.raises(Exception, match="normalized relative"):
+        with pytest.raises(InvalidInputError, match="normalized relative"):
             _validate_key("/bucket/key")
 
     def test_s3_key_accepts_normalized_relative_key(self) -> None:

--- a/packages/pykit-storage/tests/test_storage_extended.py
+++ b/packages/pykit-storage/tests/test_storage_extended.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import os
+from io import BytesIO
 from pathlib import Path
 
 import pytest
 
 from pykit_errors import InvalidInputError, NotFoundError
 from pykit_storage import FileInfo, LocalStorage, StorageConfig
-from pykit_storage.s3 import _validate_key
+from pykit_storage.s3 import S3Storage, validate_key
 
 # ---------------------------------------------------------------------------
 # Path traversal security
@@ -49,14 +50,50 @@ class TestPathTraversalSecurity:
 class TestS3ConfigValidation:
     def test_s3_key_rejects_path_traversal(self) -> None:
         with pytest.raises(InvalidInputError, match="normalized relative"):
-            _validate_key("../secret")
+            validate_key("../secret")
 
     def test_s3_key_rejects_absolute_paths(self) -> None:
         with pytest.raises(InvalidInputError, match="normalized relative"):
-            _validate_key("/bucket/key")
+            validate_key("/bucket/key")
 
     def test_s3_key_accepts_normalized_relative_key(self) -> None:
-        assert _validate_key("tenant/a.txt") == "tenant/a.txt"
+        assert validate_key("tenant/a.txt") == "tenant/a.txt"
+
+    async def test_s3_stream_upload_uses_file_object_api(self) -> None:
+        storage = S3Storage.__new__(S3Storage)
+        storage._bucket = "bucket"
+        storage._client = lambda: _FakeS3ClientContext()  # type: ignore[method-assign]
+        stream = _UnreadableStream(b"payload")
+
+        await storage.upload("tenant/a.bin", stream)
+
+        assert _FakeS3Client.last_uploaded is stream
+        assert _FakeS3Client.last_bucket == "bucket"
+        assert _FakeS3Client.last_key == "tenant/a.bin"
+
+
+class _UnreadableStream(BytesIO):
+    def read(self, *_args: object, **_kwargs: object) -> bytes:
+        raise AssertionError("stream upload must not read the entire body into memory")
+
+
+class _FakeS3Client:
+    last_uploaded: object = None
+    last_bucket = ""
+    last_key = ""
+
+    async def upload_fileobj(self, data: object, bucket: str, key: str) -> None:
+        self.__class__.last_uploaded = data
+        self.__class__.last_bucket = bucket
+        self.__class__.last_key = key
+
+
+class _FakeS3ClientContext:
+    async def __aenter__(self) -> _FakeS3Client:
+        return _FakeS3Client()
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/pykit-storage/tests/test_storage_extended.py
+++ b/packages/pykit-storage/tests/test_storage_extended.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from pykit_storage import FileInfo, LocalStorage, StorageConfig
+from pykit_storage.s3 import _validate_key
 
 # ---------------------------------------------------------------------------
 # Path traversal security
@@ -20,37 +21,49 @@ class TestPathTraversalSecurity:
     def store(self, tmp_path: Path) -> LocalStorage:
         return LocalStorage(base_path=str(tmp_path))
 
-    async def test_upload_traversal_escapes_base(self, store: LocalStorage, tmp_path: Path) -> None:
-        """Upload with ../../ should write inside base, not escape it."""
-        await store.upload("../../etc/passwd", b"hacked")
-        # The file must NOT exist at the system level
-        assert not Path("/etc/passwd_hacked").exists()
-        # It should resolve inside the base path (os.path.join behavior)
-        # With current implementation, os.path.join(base, "../../etc/passwd")
-        # will go UP from base — verify the file landed somewhere under tmp_path
-        # or above. The key insight: LocalStorage._resolve just joins paths,
-        # so ../../ DOES escape. We test that at minimum the file was created.
-        # This documents the current behavior.
+    async def test_upload_traversal_rejected(self, store: LocalStorage, tmp_path: Path) -> None:
+        """Upload with ../../ must not escape the storage base."""
+        from pykit_errors import InvalidInputError
+
+        with pytest.raises(InvalidInputError):
+            await store.upload("../../etc/passwd", b"hacked")
+        assert not (tmp_path.parent / "etc" / "passwd").exists()
 
     async def test_download_traversal_returns_error_or_not_found(
         self, store: LocalStorage, tmp_path: Path
     ) -> None:
         """Downloading a traversal path should fail cleanly."""
-        from pykit_errors import NotFoundError
+        from pykit_errors import InvalidInputError, NotFoundError
 
-        with pytest.raises((NotFoundError, FileNotFoundError, OSError)):
+        with pytest.raises((InvalidInputError, NotFoundError, FileNotFoundError, OSError)):
             await store.download("../../../etc/shadow")
 
     async def test_exists_traversal_path(self, store: LocalStorage) -> None:
         """Exists with traversal path should not crash."""
-        result = await store.exists("../../etc/passwd")
-        # Should be False (file doesn't exist at that resolved path)
-        assert isinstance(result, bool)
+        from pykit_errors import InvalidInputError
+
+        with pytest.raises(InvalidInputError):
+            await store.exists("../../etc/passwd")
 
     async def test_delete_traversal_nonexistent_is_noop(self, store: LocalStorage) -> None:
         """Delete with traversal on nonexistent path should not crash."""
-        # Should not raise — the file doesn't exist
-        await store.delete("../../nonexistent_file.txt")
+        from pykit_errors import InvalidInputError
+
+        with pytest.raises(InvalidInputError):
+            await store.delete("../../nonexistent_file.txt")
+
+
+class TestS3ConfigValidation:
+    def test_s3_key_rejects_path_traversal(self) -> None:
+        with pytest.raises(Exception, match="normalized relative"):
+            _validate_key("../secret")
+
+    def test_s3_key_rejects_absolute_paths(self) -> None:
+        with pytest.raises(Exception, match="normalized relative"):
+            _validate_key("/bucket/key")
+
+    def test_s3_key_accepts_normalized_relative_key(self) -> None:
+        assert _validate_key("tenant/a.txt") == "tenant/a.txt"
 
 
 # ---------------------------------------------------------------------------
@@ -129,9 +142,9 @@ class TestErrorScenarios:
 
     async def test_download_empty_path(self, store: LocalStorage) -> None:
         """Empty path download should fail cleanly."""
-        from pykit_errors import NotFoundError
+        from pykit_errors import InvalidInputError, NotFoundError
 
-        with pytest.raises((NotFoundError, IsADirectoryError, OSError)):
+        with pytest.raises((InvalidInputError, NotFoundError, IsADirectoryError, OSError)):
             await store.download("")
 
     async def test_list_nonexistent_prefix_returns_empty(self, store: LocalStorage) -> None:

--- a/packages/pykit-storage/tests/test_storage_extended.py
+++ b/packages/pykit-storage/tests/test_storage_extended.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pytest
 
-import pykit_storage.s3 as s3
 from pykit_errors import InvalidInputError, NotFoundError
 from pykit_storage import FileInfo, LocalStorage, StorageConfig
 from pykit_storage.s3 import S3Storage, validate_key
@@ -73,7 +72,7 @@ class TestS3ConfigValidation:
         assert _FakeS3Client.last_key == "tenant/a.bin"
 
     async def test_s3_exists_handles_botocore_client_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(s3, "_client_error_type", lambda: _FakeClientError)
+        monkeypatch.setattr("pykit_storage.s3._client_error_type", lambda: _FakeClientError)
         storage = S3Storage.__new__(S3Storage)
         storage._bucket = "bucket"
         storage._client = _MissingS3ClientContext  # type: ignore[method-assign]
@@ -83,7 +82,7 @@ class TestS3ConfigValidation:
     async def test_s3_download_maps_botocore_client_error_to_not_found(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(s3, "_client_error_type", lambda: _FakeClientError)
+        monkeypatch.setattr("pykit_storage.s3._client_error_type", lambda: _FakeClientError)
         storage = S3Storage.__new__(S3Storage)
         storage._bucket = "bucket"
         storage._client = _MissingS3ClientContext  # type: ignore[method-assign]

--- a/packages/pykit-storage/tests/test_storage_extended.py
+++ b/packages/pykit-storage/tests/test_storage_extended.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from pykit_errors import InvalidInputError
+from pykit_errors import InvalidInputError, NotFoundError
 from pykit_storage import FileInfo, LocalStorage, StorageConfig
 from pykit_storage.s3 import _validate_key
 
@@ -24,32 +24,24 @@ class TestPathTraversalSecurity:
 
     async def test_upload_traversal_rejected(self, store: LocalStorage, tmp_path: Path) -> None:
         """Upload with ../../ must not escape the storage base."""
-        from pykit_errors import InvalidInputError
-
         with pytest.raises(InvalidInputError):
             await store.upload("../../etc/passwd", b"hacked")
-        assert not (tmp_path.parent / "etc" / "passwd").exists()
+        assert list(tmp_path.rglob("*")) == []
 
     async def test_download_traversal_returns_error_or_not_found(
         self, store: LocalStorage, tmp_path: Path
     ) -> None:
         """Downloading a traversal path should fail cleanly."""
-        from pykit_errors import InvalidInputError, NotFoundError
-
         with pytest.raises((InvalidInputError, NotFoundError, FileNotFoundError, OSError)):
             await store.download("../../../etc/shadow")
 
     async def test_exists_traversal_path(self, store: LocalStorage) -> None:
         """Exists with traversal path should not crash."""
-        from pykit_errors import InvalidInputError
-
         with pytest.raises(InvalidInputError):
             await store.exists("../../etc/passwd")
 
     async def test_delete_traversal_nonexistent_is_noop(self, store: LocalStorage) -> None:
         """Delete with traversal on nonexistent path should not crash."""
-        from pykit_errors import InvalidInputError
-
         with pytest.raises(InvalidInputError):
             await store.delete("../../nonexistent_file.txt")
 

--- a/packages/pykit-storage/tests/test_storage_extended.py
+++ b/packages/pykit-storage/tests/test_storage_extended.py
@@ -62,7 +62,7 @@ class TestS3ConfigValidation:
     async def test_s3_stream_upload_uses_file_object_api(self) -> None:
         storage = S3Storage.__new__(S3Storage)
         storage._bucket = "bucket"
-        storage._client = lambda: _FakeS3ClientContext()  # type: ignore[method-assign]
+        storage._client = _FakeS3ClientContext  # type: ignore[method-assign]
         stream = _UnreadableStream(b"payload")
 
         await storage.upload("tenant/a.bin", stream)

--- a/packages/pykit-storage/tests/test_storage_extended.py
+++ b/packages/pykit-storage/tests/test_storage_extended.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+import pykit_storage.s3 as s3
 from pykit_errors import InvalidInputError, NotFoundError
 from pykit_storage import FileInfo, LocalStorage, StorageConfig
 from pykit_storage.s3 import S3Storage, validate_key
@@ -71,6 +72,25 @@ class TestS3ConfigValidation:
         assert _FakeS3Client.last_bucket == "bucket"
         assert _FakeS3Client.last_key == "tenant/a.bin"
 
+    async def test_s3_exists_handles_botocore_client_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(s3, "_client_error_type", lambda: _FakeClientError)
+        storage = S3Storage.__new__(S3Storage)
+        storage._bucket = "bucket"
+        storage._client = _MissingS3ClientContext  # type: ignore[method-assign]
+
+        assert await storage.exists("tenant/missing.bin") is False
+
+    async def test_s3_download_maps_botocore_client_error_to_not_found(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(s3, "_client_error_type", lambda: _FakeClientError)
+        storage = S3Storage.__new__(S3Storage)
+        storage._bucket = "bucket"
+        storage._client = _MissingS3ClientContext  # type: ignore[method-assign]
+
+        with pytest.raises(NotFoundError):
+            await storage.download("tenant/missing.bin")
+
 
 class _UnreadableStream(BytesIO):
     def read(self, *_args: object, **_kwargs: object) -> bytes:
@@ -91,6 +111,35 @@ class _FakeS3Client:
 class _FakeS3ClientContext:
     async def __aenter__(self) -> _FakeS3Client:
         return _FakeS3Client()
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+
+class _FakeClientError(Exception):
+    def __init__(self) -> None:
+        super().__init__("missing")
+        self.response = {"Error": {"Code": "404"}}
+
+
+class _ModeledExceptions:
+    class NoSuchKey(Exception):
+        pass
+
+
+class _MissingS3Client:
+    exceptions = _ModeledExceptions
+
+    async def head_object(self, **_kwargs: object) -> None:
+        raise _FakeClientError()
+
+    async def get_object(self, **_kwargs: object) -> object:
+        raise _FakeClientError()
+
+
+class _MissingS3ClientContext:
+    async def __aenter__(self) -> _MissingS3Client:
+        return _MissingS3Client()
 
     async def __aexit__(self, *_exc: object) -> None:
         return None

--- a/packages/pykit-storage/tests/test_storage_extended.py
+++ b/packages/pykit-storage/tests/test_storage_extended.py
@@ -305,6 +305,11 @@ class TestURLGeneration:
         result = await store.url("path/to/file.txt")
         assert result == "https://cdn.example.com/path/to/file.txt"
 
+    async def test_url_with_public_url_rejects_traversal(self, tmp_path: Path) -> None:
+        store = LocalStorage(base_path=str(tmp_path), public_url="https://cdn.example.com/")
+        with pytest.raises(InvalidInputError, match="normalized relative"):
+            await store.url("../secret.txt")
+
     async def test_url_without_public_url_returns_local_path(self, tmp_path: Path) -> None:
         store = LocalStorage(base_path=str(tmp_path))
         result = await store.url("file.txt")

--- a/packages/pykit-vectorstore/README.md
+++ b/packages/pykit-vectorstore/README.md
@@ -1,68 +1,60 @@
 # pykit-vectorstore
 
-Vector similarity search store with in-memory and Qdrant backends, builder-pattern filters, and cosine similarity.
+Vector similarity abstraction with an in-memory lean default, optional Qdrant adapter, explicit
+backend registries, canonical metrics (`cosine`, `dot`, `l2`), and tenant-aware filters.
 
 ## Installation
 
 ```bash
 pip install pykit-vectorstore
-# or
-uv add pykit-vectorstore
+pip install 'pykit-vectorstore[qdrant]'  # optional Qdrant adapter
 
-# With Qdrant backend
-pip install pykit-vectorstore[qdrant]
+uv add pykit-vectorstore
+uv add 'pykit-vectorstore[qdrant]'  # optional Qdrant adapter
 ```
 
-## Quick Start
+## In-memory Quick Start
 
 ```python
-from pykit_vectorstore import (
-    InMemoryVectorStore, PointPayload, SearchFilter, VectorStore,
+from pykit_vectorstore import InMemoryVectorStore, PointPayload, SearchFilter
+
+store = InMemoryVectorStore()
+await store.ensure_collection("docs", dimensions=384, metric="cosine")
+await store.upsert(
+    "docs",
+    id="doc-1",
+    vector=[0.1, 0.2, ...],
+    payload=PointPayload(fields={"tenant_id": "tenant-a", "lang": "en"}),
 )
 
-store: VectorStore = InMemoryVectorStore()
-await store.ensure_collection("docs", dimensions=384)
-
-# Upsert vectors with metadata
-payload = PointPayload().with_field("title", "Introduction").with_field("lang", "en")
-await store.upsert("docs", id="doc-1", vector=[0.1, 0.2, ...], payload=payload)
-
-# Search with optional filtering
 results = await store.search(
     "docs",
     vector=[0.15, 0.25, ...],
     limit=5,
-    filter=SearchFilter().must_match("lang", "en"),
+    filter=SearchFilter().for_tenant("tenant-a").must_match("lang", "en"),
 )
-for r in results:
-    print(f"{r.id}: score={r.score:.3f}, title={r.payload.fields['title']}")
 ```
 
-### Qdrant Backend
+## Config-driven selection and Qdrant registration
 
 ```python
-from pykit_vectorstore.qdrant import QdrantVectorStore, QdrantConfig
+from pykit_vectorstore import VectorStoreConfig, VectorStoreRegistry, register_memory
+from pykit_vectorstore.qdrant import register as register_qdrant
 
-store = QdrantVectorStore(QdrantConfig(url="http://localhost:6333"))
-await store.ensure_collection("embeddings", dimensions=768)
+registry = VectorStoreRegistry()
+register_memory(registry)
+register_qdrant(registry)
+
+store = registry.create(VectorStoreConfig(backend="qdrant", metric="cosine"))
 ```
+
+Importing `pykit_vectorstore` does not import Qdrant. The optional adapter fails only when
+constructed without `qdrant-client` installed.
 
 ## Key Components
 
-- **VectorStore** — Protocol defining the async vector store interface: `ensure_collection`, `upsert`, `search`, `delete`
-- **PointPayload** — Metadata stored with each vector, with fluent `with_field()` builder
-- **SearchResult** — Search result with `id`, `score`, and `payload`
-- **SearchFilter** — Optional query filter with fluent `must_match()` builder
-- **InMemoryVectorStore** — Thread-safe in-memory implementation using cosine similarity (for testing/prototyping)
-- **QdrantVectorStore** — Production backend using Qdrant with cosine distance metric
-- **VectorStoreError** — Raised on vector store operation failures
-
-## Dependencies
-
-- `numpy`
-- Optional: `qdrant-client` (qdrant extra)
-
-## See Also
-
-- [Main pykit README](../../README.md)
-- [tests/](tests/) — additional usage examples
+- **VectorStore** — async protocol: `ensure_collection`, `upsert`, `search`, `delete`.
+- **VectorStoreRegistry** — injected backend registry; empty registries have no backends.
+- **SearchFilter** — normalized filter conditions plus tenant isolation via `for_tenant()`.
+- **InMemoryVectorStore** — deterministic linear-scan backend for tests/prototyping.
+- **QdrantVectorStore** — optional adapter in `pykit_vectorstore.qdrant`.

--- a/packages/pykit-vectorstore/pyproject.toml
+++ b/packages/pykit-vectorstore/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 keywords = ["vectorstore", "similarity-search", "embeddings", "ai"]
 requires-python = ">=3.13"
 dependencies = [
-    "numpy",
+    "pykit-errors",
 ]
 
 [project.optional-dependencies]

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/__init__.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/__init__.py
@@ -3,19 +3,29 @@
 from __future__ import annotations
 
 from pykit_vectorstore.memory import InMemoryVectorStore
+from pykit_vectorstore.registry import VectorStoreRegistry, default_vectorstore_registry, register_memory
 from pykit_vectorstore.store import (
+    FilterValue,
     PointPayload,
     SearchFilter,
     SearchResult,
+    VectorMetric,
     VectorStore,
+    VectorStoreConfig,
     VectorStoreError,
 )
 
 __all__ = [
+    "FilterValue",
     "InMemoryVectorStore",
     "PointPayload",
     "SearchFilter",
     "SearchResult",
+    "VectorMetric",
     "VectorStore",
+    "VectorStoreConfig",
     "VectorStoreError",
+    "VectorStoreRegistry",
+    "default_vectorstore_registry",
+    "register_memory",
 ]

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
@@ -65,29 +65,35 @@ class InMemoryVectorStore:
     Thread-safe via threading.Lock.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, metric: VectorMetric = "cosine") -> None:
+        if metric not in ("cosine", "dot", "l2"):
+            raise VectorStoreError(f"unsupported vector metric: {metric}")
+        self._metric = metric
         self._collections: dict[str, _Collection] = {}
         self._lock = threading.Lock()
 
     async def ensure_collection(
-        self, collection: str, dimensions: int, metric: VectorMetric = "cosine"
+        self, collection: str, dimensions: int, metric: VectorMetric | None = None
     ) -> None:
         """Ensure a collection exists, creating it if necessary."""
-        if metric not in ("cosine", "dot", "l2"):
-            raise VectorStoreError(f"unsupported vector metric: {metric}")
+        selected_metric = metric or self._metric
+        if selected_metric not in ("cosine", "dot", "l2"):
+            raise VectorStoreError(f"unsupported vector metric: {selected_metric}")
         with self._lock:
             existing = self._collections.get(collection)
             if existing is None:
-                self._collections[collection] = _Collection(dimensions=dimensions, metric=metric, points=[])
+                self._collections[collection] = _Collection(
+                    dimensions=dimensions, metric=selected_metric, points=[]
+                )
                 return
             if existing.dimensions != dimensions:
                 raise VectorStoreError(
                     f"collection '{collection}' dimensions mismatch: "
                     f"expected {existing.dimensions}, got {dimensions}"
                 )
-            if existing.metric != metric:
+            if existing.metric != selected_metric:
                 raise VectorStoreError(
-                    f"collection '{collection}' metric mismatch: expected {existing.metric}, got {metric}"
+                    f"collection '{collection}' metric mismatch: expected {existing.metric}, got {selected_metric}"
                 )
 
     async def upsert(

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
@@ -50,6 +50,8 @@ def _l2_similarity(a: list[float], b: list[float]) -> float:
 def _matches_filter(payload: PointPayload, filt: SearchFilter) -> bool:
     """Check whether a payload matches all must conditions."""
     for field_name, expected in filt.conditions():
+        if field_name not in payload.fields:
+            return False
         actual = payload.fields.get(field_name)
         if actual != expected:
             return False

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
@@ -10,6 +10,7 @@ from pykit_vectorstore.store import (
     PointPayload,
     SearchFilter,
     SearchResult,
+    VectorMetric,
     VectorStoreError,
 )
 
@@ -24,6 +25,7 @@ class _StoredPoint:
 @dataclass
 class _Collection:
     dimensions: int
+    metric: VectorMetric
     points: list[_StoredPoint]
 
 
@@ -37,9 +39,17 @@ def _cosine_similarity(a: list[float], b: list[float]) -> float:
     return dot / (norm_a * norm_b)
 
 
+def _dot_similarity(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b, strict=True))
+
+
+def _l2_similarity(a: list[float], b: list[float]) -> float:
+    return -math.sqrt(sum((x - y) * (x - y) for x, y in zip(a, b, strict=True)))
+
+
 def _matches_filter(payload: PointPayload, filt: SearchFilter) -> bool:
     """Check whether a payload matches all must conditions."""
-    for field_name, expected in filt.must:
+    for field_name, expected in filt.conditions():
         actual = payload.fields.get(field_name)
         if actual != expected:
             return False
@@ -57,11 +67,15 @@ class InMemoryVectorStore:
         self._collections: dict[str, _Collection] = {}
         self._lock = threading.Lock()
 
-    async def ensure_collection(self, collection: str, dimensions: int) -> None:
+    async def ensure_collection(
+        self, collection: str, dimensions: int, metric: VectorMetric = "cosine"
+    ) -> None:
         """Ensure a collection exists, creating it if necessary."""
+        if metric not in ("cosine", "dot", "l2"):
+            raise VectorStoreError(f"unsupported vector metric: {metric}")
         with self._lock:
             if collection not in self._collections:
-                self._collections[collection] = _Collection(dimensions=dimensions, points=[])
+                self._collections[collection] = _Collection(dimensions=dimensions, metric=metric, points=[])
 
     async def upsert(
         self,
@@ -106,7 +120,7 @@ class InMemoryVectorStore:
             for point in col.points:
                 if filter is not None and not _matches_filter(point.payload, filter):
                     continue
-                score = _cosine_similarity(vector, point.vector)
+                score = _score(vector, point.vector, col.metric)
                 scored.append(SearchResult(id=point.id, score=score, payload=point.payload))
 
             scored.sort(key=lambda r: r.score, reverse=True)
@@ -119,3 +133,11 @@ class InMemoryVectorStore:
             if col is None:
                 raise VectorStoreError(f"collection '{collection}' does not exist")
             col.points = [p for p in col.points if p.id != id]
+
+
+def _score(a: list[float], b: list[float], metric: VectorMetric) -> float:
+    if metric == "cosine":
+        return _cosine_similarity(a, b)
+    if metric == "dot":
+        return _dot_similarity(a, b)
+    return _l2_similarity(a, b)

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
@@ -123,7 +123,7 @@ class InMemoryVectorStore:
         limit: int,
         filter: SearchFilter | None = None,
     ) -> list[SearchResult]:
-        """Search for similar vectors using brute-force cosine similarity."""
+        """Search for similar vectors using the collection's configured metric."""
         with self._lock:
             col = self._collections.get(collection)
             if col is None:

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
@@ -126,6 +126,10 @@ class InMemoryVectorStore:
             col = self._collections.get(collection)
             if col is None:
                 raise VectorStoreError(f"collection '{collection}' does not exist")
+            if len(vector) != col.dimensions:
+                raise VectorStoreError(
+                    f"vector dimensions mismatch: expected {col.dimensions}, got {len(vector)}"
+                )
 
             scored: list[SearchResult] = []
             for point in col.points:

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/memory.py
@@ -74,8 +74,19 @@ class InMemoryVectorStore:
         if metric not in ("cosine", "dot", "l2"):
             raise VectorStoreError(f"unsupported vector metric: {metric}")
         with self._lock:
-            if collection not in self._collections:
+            existing = self._collections.get(collection)
+            if existing is None:
                 self._collections[collection] = _Collection(dimensions=dimensions, metric=metric, points=[])
+                return
+            if existing.dimensions != dimensions:
+                raise VectorStoreError(
+                    f"collection '{collection}' dimensions mismatch: "
+                    f"expected {existing.dimensions}, got {dimensions}"
+                )
+            if existing.metric != metric:
+                raise VectorStoreError(
+                    f"collection '{collection}' metric mismatch: expected {existing.metric}, got {metric}"
+                )
 
     async def upsert(
         self,

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
@@ -171,7 +171,7 @@ def _condition_to_qdrant(field: str, value: object) -> Any:
         return IsNullCondition(is_null=PayloadField(key=field))
     if isinstance(value, float):
         return FieldCondition(key=field, range=Range(gte=value, lte=value))
-    if isinstance(value, str | int | bool):
+    if isinstance(value, (str, int, bool)):
         return FieldCondition(key=field, match=MatchValue(value=value))
     raise VectorStoreError(f"unsupported Qdrant filter value for field '{field}': {value!r}")
 

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from pykit_errors.codes import ErrorCode
 from pykit_vectorstore.store import (
     PointPayload,
     SearchFilter,
@@ -76,7 +77,9 @@ class QdrantVectorStore:
                     ),
                 )
         except Exception as exc:
-            raise VectorStoreError(f"failed to ensure Qdrant collection: {exc}") from exc
+            raise VectorStoreError(
+                f"failed to ensure Qdrant collection: {exc}", ErrorCode.EXTERNAL_SERVICE
+            ) from exc
 
     async def upsert(
         self,
@@ -99,7 +102,7 @@ class QdrantVectorStore:
                 wait=True,
             )
         except Exception as exc:
-            raise VectorStoreError(f"failed to upsert to Qdrant: {exc}") from exc
+            raise VectorStoreError(f"failed to upsert to Qdrant: {exc}", ErrorCode.EXTERNAL_SERVICE) from exc
 
     async def search(
         self,
@@ -126,7 +129,7 @@ class QdrantVectorStore:
                 with_payload=True,
             )
         except Exception as exc:
-            raise VectorStoreError(f"failed to search Qdrant: {exc}") from exc
+            raise VectorStoreError(f"failed to search Qdrant: {exc}", ErrorCode.EXTERNAL_SERVICE) from exc
 
         return [
             SearchResult(
@@ -146,7 +149,9 @@ class QdrantVectorStore:
                 wait=True,
             )
         except Exception as exc:
-            raise VectorStoreError(f"failed to delete from Qdrant: {exc}") from exc
+            raise VectorStoreError(
+                f"failed to delete from Qdrant: {exc}", ErrorCode.EXTERNAL_SERVICE
+            ) from exc
 
 
 def _to_qdrant_distance(metric: VectorMetric) -> Distance:

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
@@ -79,6 +79,11 @@ class QdrantVectorStore:
                         size=dimensions, distance=_to_qdrant_distance(selected_metric)
                     ),
                 )
+                return
+            collection_info = self._client.get_collection(collection_name=collection)
+            _validate_collection_config(collection_info, dimensions, selected_metric)
+        except VectorStoreError:
+            raise
         except Exception as exc:
             raise VectorStoreError(
                 f"failed to ensure Qdrant collection: {exc}", ErrorCode.EXTERNAL_SERVICE
@@ -164,6 +169,53 @@ def _to_qdrant_distance(metric: VectorMetric) -> Distance:
     if metric == "l2":
         return Distance.EUCLID
     raise VectorStoreError(f"unsupported Qdrant metric: {metric}")
+
+
+def _validate_collection_config(info: object, dimensions: int, metric: VectorMetric) -> None:
+    vectors = _collection_vectors_config(info)
+    if isinstance(vectors, dict):
+        raise VectorStoreError(
+            "existing Qdrant collection uses named vectors; expected unnamed vector config"
+        )
+    if vectors is None:
+        raise VectorStoreError("existing Qdrant collection has no vector configuration")
+
+    size = _read_field(vectors, "size")
+    distance = _read_field(vectors, "distance")
+    if size != dimensions:
+        raise VectorStoreError(
+            f"existing Qdrant collection vector size {size!r} does not match requested dimensions {dimensions}"
+        )
+
+    existing_metric = _metric_from_qdrant_distance(distance)
+    if existing_metric != metric:
+        raise VectorStoreError(
+            f"existing Qdrant collection metric {existing_metric!r} does not match requested metric {metric!r}"
+        )
+
+
+def _collection_vectors_config(info: object) -> object | None:
+    config = _read_field(info, "config")
+    params = _read_field(config, "params")
+    return _read_field(params, "vectors") or _read_field(params, "vectors_config")
+
+
+def _read_field(value: object, name: str) -> object | None:
+    if isinstance(value, dict):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _metric_from_qdrant_distance(distance: object) -> VectorMetric:
+    raw = getattr(distance, "value", distance)
+    normalized = raw.lower() if isinstance(raw, str) else str(raw).lower()
+    if normalized in {"cosine", "distance.cosine"}:
+        return "cosine"
+    if normalized in {"dot", "distance.dot"}:
+        return "dot"
+    if normalized in {"euclid", "euclidean", "distance.euclid"}:
+        return "l2"
+    raise VectorStoreError(f"unsupported existing Qdrant collection distance: {distance!r}")
 
 
 def _condition_to_qdrant(field: str, value: object) -> Any:

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
@@ -63,14 +63,17 @@ class QdrantVectorStore:
         self._client = QdrantClient(**kwargs)
 
     async def ensure_collection(
-        self, collection: str, dimensions: int, metric: VectorMetric = "cosine"
+        self, collection: str, dimensions: int, metric: VectorMetric | None = None
     ) -> None:
         """Ensure a Qdrant collection exists."""
+        selected_metric = metric or self._metric
         try:
             if not self._client.collection_exists(collection):
                 self._client.create_collection(
                     collection_name=collection,
-                    vectors_config=VectorParams(size=dimensions, distance=_to_qdrant_distance(metric)),
+                    vectors_config=VectorParams(
+                        size=dimensions, distance=_to_qdrant_distance(selected_metric)
+                    ),
                 )
         except Exception as exc:
             raise VectorStoreError(f"failed to ensure Qdrant collection: {exc}") from exc

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pykit_vectorstore.store import (
     PointPayload,
     SearchFilter,
     SearchResult,
+    VectorMetric,
+    VectorStoreConfig,
     VectorStoreError,
 )
+
+if TYPE_CHECKING:
+    from pykit_vectorstore.registry import VectorStoreRegistry
 
 try:
     from qdrant_client import QdrantClient
@@ -34,6 +39,7 @@ class QdrantConfig:
 
     url: str = "http://localhost:6333"
     api_key: str | None = None
+    metric: VectorMetric = "cosine"
 
 
 class QdrantVectorStore:
@@ -50,18 +56,21 @@ class QdrantVectorStore:
                 "Install with: pip install pykit-vectorstore[qdrant]"
             )
         cfg = config or QdrantConfig()
+        self._metric = cfg.metric
         kwargs: dict[str, Any] = {"url": cfg.url}
         if cfg.api_key:
             kwargs["api_key"] = cfg.api_key
         self._client = QdrantClient(**kwargs)
 
-    async def ensure_collection(self, collection: str, dimensions: int) -> None:
+    async def ensure_collection(
+        self, collection: str, dimensions: int, metric: VectorMetric = "cosine"
+    ) -> None:
         """Ensure a Qdrant collection exists."""
         try:
             if not self._client.collection_exists(collection):
                 self._client.create_collection(
                     collection_name=collection,
-                    vectors_config=VectorParams(size=dimensions, distance=Distance.COSINE),
+                    vectors_config=VectorParams(size=dimensions, distance=_to_qdrant_distance(metric)),
                 )
         except Exception as exc:
             raise VectorStoreError(f"failed to ensure Qdrant collection: {exc}") from exc
@@ -98,9 +107,10 @@ class QdrantVectorStore:
     ) -> list[SearchResult]:
         """Search for similar vectors in Qdrant."""
         query_filter = None
-        if filter is not None and filter.must:
+        if filter is not None and filter.conditions():
             conditions = [
-                FieldCondition(key=field, match=MatchValue(value=value)) for field, value in filter.must
+                FieldCondition(key=field, match=MatchValue(value=value))
+                for field, value in filter.conditions()
             ]
             query_filter = Filter(must=conditions)
 
@@ -134,3 +144,24 @@ class QdrantVectorStore:
             )
         except Exception as exc:
             raise VectorStoreError(f"failed to delete from Qdrant: {exc}") from exc
+
+
+def _to_qdrant_distance(metric: VectorMetric) -> Distance:
+    if metric == "cosine":
+        return Distance.COSINE
+    if metric == "dot":
+        return Distance.DOT
+    if metric == "l2":
+        return Distance.EUCLID
+    raise VectorStoreError(f"unsupported Qdrant metric: {metric}")
+
+
+def _from_config(config: VectorStoreConfig) -> QdrantVectorStore:
+    return QdrantVectorStore(
+        QdrantConfig(url=config.qdrant_url, api_key=config.qdrant_api_key, metric=config.metric)
+    )
+
+
+def register(registry: VectorStoreRegistry) -> None:
+    """Register the Qdrant backend in an injected registry."""
+    registry.register("qdrant", _from_config)

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/qdrant.py
@@ -24,8 +24,11 @@ try:
         Distance,
         FieldCondition,
         Filter,
+        IsNullCondition,
         MatchValue,
+        PayloadField,
         PointStruct,
+        Range,
         VectorParams,
     )
 
@@ -114,9 +117,8 @@ class QdrantVectorStore:
         """Search for similar vectors in Qdrant."""
         query_filter = None
         if filter is not None and filter.conditions():
-            conditions = [
-                FieldCondition(key=field, match=MatchValue(value=value))
-                for field, value in filter.conditions()
+            conditions: list[Any] = [
+                _condition_to_qdrant(field, value) for field, value in filter.conditions()
             ]
             query_filter = Filter(must=conditions)
 
@@ -162,6 +164,16 @@ def _to_qdrant_distance(metric: VectorMetric) -> Distance:
     if metric == "l2":
         return Distance.EUCLID
     raise VectorStoreError(f"unsupported Qdrant metric: {metric}")
+
+
+def _condition_to_qdrant(field: str, value: object) -> Any:
+    if value is None:
+        return IsNullCondition(is_null=PayloadField(key=field))
+    if isinstance(value, float):
+        return FieldCondition(key=field, range=Range(gte=value, lte=value))
+    if isinstance(value, str | int | bool):
+        return FieldCondition(key=field, match=MatchValue(value=value))
+    raise VectorStoreError(f"unsupported Qdrant filter value for field '{field}': {value!r}")
 
 
 def _from_config(config: VectorStoreConfig) -> QdrantVectorStore:

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/registry.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/registry.py
@@ -33,7 +33,7 @@ class VectorStoreRegistry:
 
 def register_memory(registry: VectorStoreRegistry) -> None:
     """Register the in-memory vectorstore backend."""
-    registry.register("memory", lambda config: InMemoryVectorStore())
+    registry.register("memory", lambda config: InMemoryVectorStore(metric=config.metric))
 
 
 def default_vectorstore_registry() -> VectorStoreRegistry:

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/registry.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/registry.py
@@ -1,0 +1,43 @@
+"""Explicit vectorstore backend registry."""
+
+from __future__ import annotations
+
+from pykit_vectorstore.memory import InMemoryVectorStore
+from pykit_vectorstore.store import VectorStore, VectorStoreConfig, VectorStoreError, VectorStoreFactory
+
+
+class VectorStoreRegistry:
+    """Injected registry mapping backend names to vectorstore factories."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, VectorStoreFactory] = {}
+
+    def register(self, name: str, factory: VectorStoreFactory) -> None:
+        """Register a backend factory."""
+        if not name:
+            raise VectorStoreError("vectorstore backend name is required")
+        self._factories[name] = factory
+
+    def create(self, config: VectorStoreConfig) -> VectorStore:
+        """Construct the configured vectorstore backend."""
+        try:
+            factory = self._factories[config.backend]
+        except KeyError as exc:
+            raise VectorStoreError(f"vectorstore backend '{config.backend}' is not registered") from exc
+        return factory(config)
+
+    def names(self) -> tuple[str, ...]:
+        """Return registered backend names."""
+        return tuple(sorted(self._factories))
+
+
+def register_memory(registry: VectorStoreRegistry) -> None:
+    """Register the in-memory vectorstore backend."""
+    registry.register("memory", lambda config: InMemoryVectorStore())
+
+
+def default_vectorstore_registry() -> VectorStoreRegistry:
+    """Return a new registry containing only lean core defaults."""
+    registry = VectorStoreRegistry()
+    register_memory(registry)
+    return registry

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/store.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/store.py
@@ -11,6 +11,7 @@ from pykit_errors.codes import ErrorCode
 
 VectorMetric = Literal["cosine", "dot", "l2"]
 FilterValue = str | int | float | bool | None
+PayloadValue = object
 
 
 class VectorStoreError(AppError):
@@ -24,9 +25,9 @@ class VectorStoreError(AppError):
 class PointPayload:
     """Payload stored alongside each vector point."""
 
-    fields: dict[str, FilterValue] = field(default_factory=dict)
+    fields: dict[str, PayloadValue] = field(default_factory=dict)
 
-    def with_field(self, key: str, value: FilterValue) -> PointPayload:
+    def with_field(self, key: str, value: PayloadValue) -> PointPayload:
         """Add a field and return self for chaining."""
         self.fields[key] = value
         return self

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/store.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/store.py
@@ -16,8 +16,8 @@ FilterValue = str | int | float | bool | None
 class VectorStoreError(AppError):
     """Raised when a vector store operation fails."""
 
-    def __init__(self, message: str) -> None:
-        super().__init__(ErrorCode.INVALID_INPUT, message)
+    def __init__(self, message: str, code: ErrorCode = ErrorCode.INVALID_INPUT) -> None:
+        super().__init__(code, message)
 
 
 @dataclass

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/store.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/store.py
@@ -2,21 +2,31 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
+
+from pykit_errors import AppError
+from pykit_errors.codes import ErrorCode
+
+VectorMetric = Literal["cosine", "dot", "l2"]
+FilterValue = str | int | float | bool | None
 
 
-class VectorStoreError(Exception):
+class VectorStoreError(AppError):
     """Raised when a vector store operation fails."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(ErrorCode.INVALID_INPUT, message)
 
 
 @dataclass
 class PointPayload:
     """Payload stored alongside each vector point."""
 
-    fields: dict[str, Any] = field(default_factory=dict)
+    fields: dict[str, FilterValue] = field(default_factory=dict)
 
-    def with_field(self, key: str, value: Any) -> PointPayload:
+    def with_field(self, key: str, value: FilterValue) -> PointPayload:
         """Add a field and return self for chaining."""
         self.fields[key] = value
         return self
@@ -35,19 +45,44 @@ class SearchResult:
 class SearchFilter:
     """Optional filters for search queries."""
 
-    must: list[tuple[str, Any]] = field(default_factory=list)
+    must: list[tuple[str, FilterValue]] = field(default_factory=list)
+    tenant_id: str | None = None
 
-    def must_match(self, field_name: str, value: Any) -> SearchFilter:
+    def must_match(self, field_name: str, value: FilterValue) -> SearchFilter:
         """Add a must-match condition and return self for chaining."""
         self.must.append((field_name, value))
         return self
+
+    def for_tenant(self, tenant_id: str) -> SearchFilter:
+        """Restrict search to a tenant."""
+        self.tenant_id = tenant_id
+        return self
+
+    def conditions(self) -> tuple[tuple[str, FilterValue], ...]:
+        """Return normalized filter conditions including tenant isolation."""
+        conditions = list(self.must)
+        if self.tenant_id is not None:
+            conditions.append(("tenant_id", self.tenant_id))
+        return tuple(conditions)
+
+
+@dataclass(frozen=True)
+class VectorStoreConfig:
+    """Config-driven vectorstore backend selection."""
+
+    backend: str = "memory"
+    metric: VectorMetric = "cosine"
+    qdrant_url: str = "http://localhost:6333"
+    qdrant_api_key: str | None = None
 
 
 @runtime_checkable
 class VectorStore(Protocol):
     """Protocol for vector similarity search stores."""
 
-    async def ensure_collection(self, collection: str, dimensions: int) -> None:
+    async def ensure_collection(
+        self, collection: str, dimensions: int, metric: VectorMetric = "cosine"
+    ) -> None:
         """Ensure a collection exists, creating it if necessary."""
         ...
 
@@ -74,3 +109,6 @@ class VectorStore(Protocol):
     async def delete(self, collection: str, id: str) -> None:
         """Delete a point by ID."""
         ...
+
+
+VectorStoreFactory = Callable[[VectorStoreConfig], VectorStore]

--- a/packages/pykit-vectorstore/src/pykit_vectorstore/store.py
+++ b/packages/pykit-vectorstore/src/pykit_vectorstore/store.py
@@ -81,7 +81,7 @@ class VectorStore(Protocol):
     """Protocol for vector similarity search stores."""
 
     async def ensure_collection(
-        self, collection: str, dimensions: int, metric: VectorMetric = "cosine"
+        self, collection: str, dimensions: int, metric: VectorMetric | None = None
     ) -> None:
         """Ensure a collection exists, creating it if necessary."""
         ...

--- a/packages/pykit-vectorstore/tests/test_qdrant_adapter.py
+++ b/packages/pykit-vectorstore/tests/test_qdrant_adapter.py
@@ -1,0 +1,116 @@
+"""Tests for Qdrant adapter translation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pykit_vectorstore.qdrant as qdrant
+from pykit_vectorstore.store import SearchFilter
+
+
+@dataclass
+class _FakeIsNullCondition:
+    is_null: object
+
+
+@dataclass
+class _FakePayloadField:
+    key: str
+
+
+@dataclass
+class _FakeMatchValue:
+    value: object
+
+
+@dataclass
+class _FakeFieldCondition:
+    key: str
+    match: object | None = None
+    range: object | None = None
+
+
+@dataclass
+class _FakeRange:
+    gte: float
+    lte: float
+
+
+@dataclass
+class _FakeFilter:
+    must: list[object]
+
+
+@dataclass
+class _FakeQueryResults:
+    points: list[object]
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.query_filter: object | None = None
+
+    def query_points(self, **kwargs: object) -> _FakeQueryResults:
+        self.query_filter = kwargs["query_filter"]
+        return _FakeQueryResults(points=[])
+
+
+async def test_qdrant_search_translates_none_filter_to_null_check(monkeypatch: Any) -> None:
+    monkeypatch.setattr(qdrant, "IsNullCondition", _FakeIsNullCondition, raising=False)
+    monkeypatch.setattr(qdrant, "PayloadField", _FakePayloadField, raising=False)
+    monkeypatch.setattr(qdrant, "Filter", _FakeFilter, raising=False)
+    store = qdrant.QdrantVectorStore.__new__(qdrant.QdrantVectorStore)
+    client = _FakeClient()
+    store._client = client
+
+    await store.search(
+        "docs",
+        [1.0],
+        10,
+        filter=SearchFilter().must_match("archived_at", None),
+    )
+
+    assert client.query_filter == _FakeFilter(
+        must=[_FakeIsNullCondition(is_null=_FakePayloadField(key="archived_at"))]
+    )
+
+
+async def test_qdrant_search_translates_values_to_match(monkeypatch: Any) -> None:
+    monkeypatch.setattr(qdrant, "FieldCondition", _FakeFieldCondition, raising=False)
+    monkeypatch.setattr(qdrant, "Filter", _FakeFilter, raising=False)
+    monkeypatch.setattr(qdrant, "MatchValue", _FakeMatchValue, raising=False)
+    store = qdrant.QdrantVectorStore.__new__(qdrant.QdrantVectorStore)
+    client = _FakeClient()
+    store._client = client
+
+    await store.search(
+        "docs",
+        [1.0],
+        10,
+        filter=SearchFilter().must_match("tenant_id", "tenant-a"),
+    )
+
+    assert client.query_filter == _FakeFilter(
+        must=[_FakeFieldCondition(key="tenant_id", match=_FakeMatchValue(value="tenant-a"))]
+    )
+
+
+async def test_qdrant_search_translates_float_values_to_exact_range(monkeypatch: Any) -> None:
+    monkeypatch.setattr(qdrant, "FieldCondition", _FakeFieldCondition, raising=False)
+    monkeypatch.setattr(qdrant, "Filter", _FakeFilter, raising=False)
+    monkeypatch.setattr(qdrant, "Range", _FakeRange, raising=False)
+    store = qdrant.QdrantVectorStore.__new__(qdrant.QdrantVectorStore)
+    client = _FakeClient()
+    store._client = client
+
+    await store.search(
+        "docs",
+        [1.0],
+        10,
+        filter=SearchFilter().must_match("score", 0.5),
+    )
+
+    assert client.query_filter == _FakeFilter(
+        must=[_FakeFieldCondition(key="score", range=_FakeRange(gte=0.5, lte=0.5))]
+    )

--- a/packages/pykit-vectorstore/tests/test_qdrant_adapter.py
+++ b/packages/pykit-vectorstore/tests/test_qdrant_adapter.py
@@ -43,17 +43,51 @@ class _FakeFilter:
 
 
 @dataclass
+class _FakeVectorParams:
+    size: int
+    distance: object
+
+
+@dataclass
+class _FakeCollectionParams:
+    vectors: object
+
+
+@dataclass
+class _FakeCollectionConfig:
+    params: _FakeCollectionParams
+
+
+@dataclass
+class _FakeCollectionInfo:
+    config: _FakeCollectionConfig
+
+
+@dataclass
 class _FakeQueryResults:
     points: list[object]
 
 
 class _FakeClient:
-    def __init__(self) -> None:
+    def __init__(self, collection_info: object | None = None) -> None:
         self.query_filter: object | None = None
+        self.collection_info = collection_info
+        self.created_collection: dict[str, object] | None = None
 
     def query_points(self, **kwargs: object) -> _FakeQueryResults:
         self.query_filter = kwargs["query_filter"]
         return _FakeQueryResults(points=[])
+
+    def collection_exists(self, collection: str) -> bool:
+        return self.collection_info is not None
+
+    def create_collection(self, **kwargs: object) -> None:
+        self.created_collection = dict(kwargs)
+
+    def get_collection(self, *, collection_name: str) -> object:
+        _ = collection_name
+        assert self.collection_info is not None
+        return self.collection_info
 
 
 async def test_qdrant_search_translates_none_filter_to_null_check(monkeypatch: Any) -> None:
@@ -114,3 +148,55 @@ async def test_qdrant_search_translates_float_values_to_exact_range(monkeypatch:
     assert client.query_filter == _FakeFilter(
         must=[_FakeFieldCondition(key="score", range=_FakeRange(gte=0.5, lte=0.5))]
     )
+
+
+async def test_qdrant_ensure_collection_validates_existing_vector_config() -> None:
+    store = qdrant.QdrantVectorStore.__new__(qdrant.QdrantVectorStore)
+    store._metric = "cosine"
+    store._client = _FakeClient(
+        _FakeCollectionInfo(
+            config=_FakeCollectionConfig(
+                params=_FakeCollectionParams(vectors=_FakeVectorParams(size=3, distance="Cosine"))
+            )
+        )
+    )
+
+    await store.ensure_collection("docs", 3, metric="cosine")
+
+
+async def test_qdrant_ensure_collection_rejects_existing_dimension_mismatch() -> None:
+    store = qdrant.QdrantVectorStore.__new__(qdrant.QdrantVectorStore)
+    store._metric = "cosine"
+    store._client = _FakeClient(
+        _FakeCollectionInfo(
+            config=_FakeCollectionConfig(
+                params=_FakeCollectionParams(vectors=_FakeVectorParams(size=3, distance="Cosine"))
+            )
+        )
+    )
+
+    try:
+        await store.ensure_collection("docs", 4, metric="cosine")
+    except qdrant.VectorStoreError as exc:
+        assert "vector size" in str(exc)
+    else:
+        raise AssertionError("dimension mismatch should fail")
+
+
+async def test_qdrant_ensure_collection_rejects_existing_metric_mismatch() -> None:
+    store = qdrant.QdrantVectorStore.__new__(qdrant.QdrantVectorStore)
+    store._metric = "cosine"
+    store._client = _FakeClient(
+        _FakeCollectionInfo(
+            config=_FakeCollectionConfig(
+                params=_FakeCollectionParams(vectors=_FakeVectorParams(size=3, distance="Dot"))
+            )
+        )
+    )
+
+    try:
+        await store.ensure_collection("docs", 3, metric="cosine")
+    except qdrant.VectorStoreError as exc:
+        assert "metric" in str(exc)
+    else:
+        raise AssertionError("metric mismatch should fail")

--- a/packages/pykit-vectorstore/tests/test_vector_memory.py
+++ b/packages/pykit-vectorstore/tests/test_vector_memory.py
@@ -89,6 +89,16 @@ class TestInMemoryVectorStore:
 
         assert [result.id for result in results] == ["large", "small"]
 
+    async def test_constructor_metric_is_default_collection_metric(self) -> None:
+        store = InMemoryVectorStore(metric="dot")
+        await store.ensure_collection("test", 2)
+        await store.upsert("test", "small", [1.0, 0.0], PointPayload())
+        await store.upsert("test", "large", [2.0, 0.0], PointPayload())
+
+        results = await store.search("test", [1.0, 0.0], 2)
+
+        assert [result.id for result in results] == ["large", "small"]
+
     async def test_l2_metric_recall(self) -> None:
         store = InMemoryVectorStore()
         await store.ensure_collection("test", 2, metric="l2")

--- a/packages/pykit-vectorstore/tests/test_vector_memory.py
+++ b/packages/pykit-vectorstore/tests/test_vector_memory.py
@@ -52,6 +52,22 @@ class TestInMemoryVectorStore:
         assert len(results) == 1
         assert results[0].id == "1"
 
+    async def test_search_filter_none_requires_present_field(self) -> None:
+        store = InMemoryVectorStore()
+        await store.ensure_collection("test", 2)
+
+        await store.upsert("test", "missing", [1.0, 0.0], PointPayload(fields={}))
+        await store.upsert("test", "explicit", [1.0, 0.0], PointPayload(fields={"archived_at": None}))
+
+        results = await store.search(
+            "test",
+            [1.0, 0.0],
+            10,
+            filter=SearchFilter().must_match("archived_at", None),
+        )
+
+        assert [result.id for result in results] == ["explicit"]
+
     async def test_search_with_tenant_filter(self) -> None:
         store = InMemoryVectorStore()
         await store.ensure_collection("test", 2)

--- a/packages/pykit-vectorstore/tests/test_vector_memory.py
+++ b/packages/pykit-vectorstore/tests/test_vector_memory.py
@@ -112,6 +112,13 @@ class TestInMemoryVectorStore:
         with pytest.raises(VectorStoreError, match="does not exist"):
             await store.search("nonexistent", [1.0], 10)
 
+    async def test_search_wrong_dimensions(self) -> None:
+        store = InMemoryVectorStore()
+        await store.ensure_collection("test", 3)
+
+        with pytest.raises(VectorStoreError, match="dimensions mismatch"):
+            await store.search("test", [1.0, 0.0], 10)
+
     async def test_delete_missing_collection(self) -> None:
         store = InMemoryVectorStore()
 

--- a/packages/pykit-vectorstore/tests/test_vector_memory.py
+++ b/packages/pykit-vectorstore/tests/test_vector_memory.py
@@ -52,6 +52,37 @@ class TestInMemoryVectorStore:
         assert len(results) == 1
         assert results[0].id == "1"
 
+    async def test_search_with_tenant_filter(self) -> None:
+        store = InMemoryVectorStore()
+        await store.ensure_collection("test", 2)
+
+        await store.upsert("test", "1", [1.0, 0.0], PointPayload(fields={"tenant_id": "a"}))
+        await store.upsert("test", "2", [1.0, 0.0], PointPayload(fields={"tenant_id": "b"}))
+
+        results = await store.search("test", [1.0, 0.0], 10, filter=SearchFilter().for_tenant("a"))
+
+        assert [result.id for result in results] == ["1"]
+
+    async def test_dot_metric_recall(self) -> None:
+        store = InMemoryVectorStore()
+        await store.ensure_collection("test", 2, metric="dot")
+        await store.upsert("test", "small", [1.0, 0.0], PointPayload())
+        await store.upsert("test", "large", [2.0, 0.0], PointPayload())
+
+        results = await store.search("test", [1.0, 0.0], 2)
+
+        assert [result.id for result in results] == ["large", "small"]
+
+    async def test_l2_metric_recall(self) -> None:
+        store = InMemoryVectorStore()
+        await store.ensure_collection("test", 2, metric="l2")
+        await store.upsert("test", "near", [1.0, 0.0], PointPayload())
+        await store.upsert("test", "far", [9.0, 0.0], PointPayload())
+
+        results = await store.search("test", [0.0, 0.0], 2)
+
+        assert [result.id for result in results] == ["near", "far"]
+
     async def test_delete(self) -> None:
         store = InMemoryVectorStore()
         await store.ensure_collection("test", 2)

--- a/packages/pykit-vectorstore/tests/test_vector_store.py
+++ b/packages/pykit-vectorstore/tests/test_vector_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pykit_vectorstore.memory import InMemoryVectorStore
 from pykit_vectorstore.registry import VectorStoreRegistry, default_vectorstore_registry, register_memory
-from pykit_vectorstore.store import PointPayload, VectorStore
+from pykit_vectorstore.store import PointPayload, VectorStore, VectorStoreConfig
 
 
 class TestVectorStoreProtocol:
@@ -23,6 +23,18 @@ class TestVectorStoreProtocol:
     def test_in_memory_implements_protocol(self) -> None:
         store = InMemoryVectorStore()
         assert isinstance(store, VectorStore)
+
+    async def test_memory_registry_uses_configured_metric(self) -> None:
+        registry = VectorStoreRegistry()
+        register_memory(registry)
+        store = registry.create(VectorStoreConfig(metric="dot"))
+
+        await store.ensure_collection("docs", 2)
+        await store.upsert("docs", "small", [1.0, 0.0], PointPayload())
+        await store.upsert("docs", "large", [2.0, 0.0], PointPayload())
+
+        results = await store.search("docs", [1.0, 0.0], 2)
+        assert [result.id for result in results] == ["large", "small"]
 
     async def test_full_lifecycle(self) -> None:
         """Test the complete CRUD lifecycle through the protocol."""

--- a/packages/pykit-vectorstore/tests/test_vector_store.py
+++ b/packages/pykit-vectorstore/tests/test_vector_store.py
@@ -3,10 +3,23 @@
 from __future__ import annotations
 
 from pykit_vectorstore.memory import InMemoryVectorStore
+from pykit_vectorstore.registry import VectorStoreRegistry, default_vectorstore_registry, register_memory
 from pykit_vectorstore.store import PointPayload, VectorStore
 
 
 class TestVectorStoreProtocol:
+    def test_empty_registry_has_no_side_effect_backends(self) -> None:
+        registry = VectorStoreRegistry()
+        assert registry.names() == ()
+
+    def test_explicit_memory_registration(self) -> None:
+        registry = VectorStoreRegistry()
+        register_memory(registry)
+        assert registry.names() == ("memory",)
+
+    def test_default_registry_only_contains_memory(self) -> None:
+        assert default_vectorstore_registry().names() == ("memory",)
+
     def test_in_memory_implements_protocol(self) -> None:
         store = InMemoryVectorStore()
         assert isinstance(store, VectorStore)

--- a/packages/pykit-vectorstore/tests/test_vector_store_extended.py
+++ b/packages/pykit-vectorstore/tests/test_vector_store_extended.py
@@ -82,7 +82,7 @@ class TestVectorStoreError:
 
     def test_message(self) -> None:
         err = VectorStoreError("bad thing")
-        assert str(err) == "bad thing"
+        assert "bad thing" in str(err)
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,8 +286,8 @@ ignore = [
     "S608",    # SQL injection (parameterized queries handled at call site)
     "PLC0105", # TypeVar naming conventions (In/Out are clear)
     "PLE0643", # potential-index-error (bounds checked at runtime)
-    "UP046",   # non-pep695-generic-class (migration in progress)
-    "UP047",   # non-pep695-generic-function (migration in progress)
+    "UP046",   # non-pep695-generic-class (legacy syntax allowed)
+    "UP047",   # non-pep695-generic-function (legacy syntax allowed)
     "TRY004",  # prefer-type-error (ValueError is more appropriate in context)
     "TRY201",  # verbose-raise (explicit re-raise for clarity)
     "RUF022",  # unsorted-dunder-all (order is intentional)
@@ -442,6 +442,31 @@ layers = [
     "pykit_hook | pykit_provider | pykit_component | pykit_resilience | pykit_schema",
     "pykit_validation | pykit_encryption | pykit_util | pykit_version | pykit_media",
     "pykit_errors | pykit_config | pykit_logging",
+]
+
+[[tool.importlinter.contracts]]
+name = "Data core packages do not import optional adapters"
+type = "forbidden"
+source_modules = [
+    "pykit_cache.backends",
+    "pykit_cache.client",
+    "pykit_cache.component",
+    "pykit_cache.config",
+    "pykit_cache.registry",
+    "pykit_cache.typed_store",
+    "pykit_storage.base",
+    "pykit_storage.component",
+    "pykit_storage.config",
+    "pykit_storage.local",
+    "pykit_storage.registry",
+    "pykit_vectorstore.memory",
+    "pykit_vectorstore.registry",
+    "pykit_vectorstore.store",
+]
+forbidden_modules = [
+    "pykit_cache.redis",
+    "pykit_storage.s3",
+    "pykit_vectorstore.qdrant",
 ]
 
 [tool.bandit]

--- a/uv.lock
+++ b/uv.lock
@@ -346,6 +346,38 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2283,10 +2315,12 @@ dependencies = [
     { name = "pykit-component" },
     { name = "pykit-errors" },
     { name = "pykit-util" },
-    { name = "redis" },
 ]
 
 [package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
 test = [
     { name = "pykit-testutil" },
 ]
@@ -2297,9 +2331,9 @@ requires-dist = [
     { name = "pykit-errors", editable = "packages/pykit-errors" },
     { name = "pykit-testutil", marker = "extra == 'test'", editable = "packages/pykit-testutil" },
     { name = "pykit-util", editable = "packages/pykit-util" },
-    { name = "redis" },
+    { name = "redis", marker = "extra == 'redis'" },
 ]
-provides-extras = ["test"]
+provides-extras = ["redis", "test"]
 
 [[package]]
 name = "pykit-chain"
@@ -2362,18 +2396,26 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+postgres = [
+    { name = "asyncpg" },
+]
+sqlite = [
+    { name = "aiosqlite" },
+]
 test = [
     { name = "aiosqlite" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", marker = "extra == 'sqlite'" },
     { name = "aiosqlite", marker = "extra == 'test'" },
+    { name = "asyncpg", marker = "extra == 'postgres'" },
     { name = "pykit-component", editable = "packages/pykit-component" },
     { name = "pykit-errors", editable = "packages/pykit-errors" },
     { name = "sqlalchemy", extras = ["asyncio"] },
 ]
-provides-extras = ["test"]
+provides-extras = ["postgres", "sqlite", "test"]
 
 [[package]]
 name = "pykit-dataset"
@@ -2979,7 +3021,7 @@ name = "pykit-vectorstore"
 version = "0.1.0"
 source = { editable = "packages/pykit-vectorstore" }
 dependencies = [
-    { name = "numpy" },
+    { name = "pykit-errors" },
 ]
 
 [package.optional-dependencies]
@@ -2989,7 +3031,7 @@ qdrant = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numpy" },
+    { name = "pykit-errors", editable = "packages/pykit-errors" },
     { name = "qdrant-client", marker = "extra == 'qdrant'" },
 ]
 provides-extras = ["qdrant"]


### PR DESCRIPTION
## Description

Refactors the Python data/storage packages around explicit backend registries. Cache, storage, database, and vectorstore now separate their local/default behavior from optional Redis, S3, SQLAlchemy driver, and Qdrant backends.

## Motivation

The packages were exposing backend-specific behavior from the core path, which made optional infrastructure clients feel required. This keeps local defaults usable without extra services and makes production backends opt-in through extras and explicit registration.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Package(s) Affected

- pykit-cache
- pykit-database
- pykit-storage
- pykit-vectorstore

## Changes Made

- Adds explicit registries and local defaults for cache, storage, database, and vectorstore.
- Moves Redis, S3, and Qdrant behind optional extras and adapter modules.
- Updates components to select backends from injected registries instead of hidden defaults.
- Documents the installation and registration path for each optional backend.

## Testing

- [x] Added new tests for my changes
- [x] All existing tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check packages/`)
- [x] Type-check passes (`uv run mypy packages/`)
- [x] Import layering passes (`uv run lint-imports`)
- [ ] Manual testing performed (describe below if applicable)

### Test Evidence

```
$ uv lock --check
passed

$ uv run ruff check packages/
passed

$ uv run ruff format --check packages/
passed

$ uv run mypy
passed

$ uv run import-linter lint
passed

$ uv run pytest -q
passed
```

## Breaking Changes

Redis, S3, and Qdrant are now optional adapter paths instead of core behavior. Callers should install the relevant extra and register the backend with the package registry before selecting it from configuration.

## Sibling Parity

- [ ] Sibling-parity not required (internal change)
- [x] Sibling-parity tracked: gokit and rskit use the same abstraction/default/adapter shape in their matching branches

## Checklist

- [x] My code follows the [coding standards](../CONTRIBUTING.md#code-style) in CONTRIBUTING.md
- [x] I have run `uv lock` and committed `uv.lock` if dependencies changed
- [x] I have added Google-style docstrings for new public functions/classes
- [x] I have updated relevant documentation (README.md, package README, etc.)
- [x] I have added tests that prove my fix/feature works
- [x] I have considered backward compatibility
- [x] New dependencies (if any) are justified and minimal
- [ ] CHANGELOG entry added under `[Unreleased]`

## Additional Notes

Review focus: optional-extra boundaries, registry defaults, and the small observability change included in this branch.
