### PR TITLE
Refactor messaging adapters and config

### DIFF
--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -50,7 +50,7 @@ pykit is a **uv workspace** with a facade package and 50+ independent sub-packag
 | `pykit-database` | Async database access with SQLAlchemy and asyncpg |
 | `pykit-cache` | cache client and caching utilities |
 | `pykit-storage` | Object/file storage abstraction — local and S3 backends |
-| `pykit-messaging` | Transport-agnostic messaging with Kafka provider and middleware — DLQ, retry, metrics, tracing |
+| `pykit-messaging` | Transport-agnostic messaging registry with memory default, optional Kafka/NATS/RabbitMQ extras, DLQ, retry, metrics, and tracing |
 | `pykit-httpclient` | Async HTTP client with bounded redirects and resilience integration |
 
 ## Servers

--- a/packages/pykit-messaging/README.md
+++ b/packages/pykit-messaging/README.md
@@ -1,6 +1,6 @@
 # pykit-messaging
 
-Transport-agnostic messaging abstractions with Kafka provider, in-memory broker for testing, and middleware support.
+Transport-agnostic messaging abstractions with optional Kafka, NATS, and RabbitMQ adapters, in-memory broker for testing, and middleware support.
 
 ## Installation
 
@@ -9,8 +9,10 @@ pip install pykit-messaging
 # or
 uv add pykit-messaging
 
-# With Kafka support
+# With Kafka, NATS, or RabbitMQ support
 pip install pykit-messaging[kafka]
+pip install pykit-messaging[nats]
+pip install pykit-messaging[rabbitmq]
 
 # With provider bridges (pykit-provider, pykit-pipeline, pykit-dag, pykit-worker)
 pip install pykit-messaging[bridges]
@@ -25,8 +27,7 @@ from pykit_messaging import (
     assert_published_n, wait_for_message,
 )
 
-# Production: use KafkaProducer / KafkaConsumer
-# Testing: use InMemoryBroker
+# Testing: use InMemoryBroker directly.
 broker = InMemoryBroker()
 producer = broker.producer()
 consumer = broker.consumer(["orders"])
@@ -37,18 +38,43 @@ msg = await wait_for_message(broker, "orders", timeout=1.0)
 assert_published_n(broker, "orders", 1)
 ```
 
-### Kafka Setup
+### Adapter registration
+
+Optional broker SDKs are never imported by `import pykit_messaging`. Adapter modules keep config in `config.py` and lazily import SDK clients at connection time with extra-specific install errors. Register adapters explicitly in composition code; registration is config-free and each producer/consumer creation receives the typed adapter config.
 
 ```python
-from pykit_messaging import KafkaConfig, KafkaComponent
+from pykit_messaging import MessagingRegistry
+from pykit_messaging.memory import register as register_memory
+from pykit_messaging.kafka import KafkaConfig, register as register_kafka
 
-config = KafkaConfig(name="my-app", brokers="localhost:9092")
-component = KafkaComponent(config)
-await component.start()
+registry = MessagingRegistry()
+register_memory(registry)
+register_kafka(registry)
 
-producer = component.producer
-await producer.send("events", b'{"action": "click"}', key=b"user-1")
+producer = registry.producer(
+    KafkaConfig(brokers=["kafka.internal:9093"], security_protocol="SSL")
+)
+await producer.start()
+await producer.send("events", b'{"action": "click"}', key="user-1")
 ```
+
+### Configuration model
+
+`BrokerConfig` contains only broker-neutral policy: backend selection, name/enabled flags,
+delivery guarantee, commit strategy, DLQ policy, retry/request timeout settings,
+`max_in_flight`, `consumer_group`, and backend-neutral `topics`/`subscriptions`. Broker
+endpoints, protocol security credentials, batching, compression, routing/exchange details,
+and adapter-specific timeouts live in adapter configs such as `KafkaConfig`, `NatsConfig`,
+`RabbitMqConfig`, and `MemoryConfig`. Kafka, NATS, and RabbitMQ SDKs stay isolated behind
+optional extras; core and memory imports do not pull optional SDKs into the runtime graph.
+
+Factories validate creation-time config. Unsupported shared semantics are rejected with
+`AppError` instead of being silently ignored; for example, core NATS subjects reject ack-based
+at-least-once/exactly-once settings, RabbitMQ requires `auto_ack` to match `commit_strategy`,
+and Kafka exactly-once delivery requires a `transactional_id`. Secure connection settings are
+the default (`SSL`, `tls://`, `amqps://`); plaintext development endpoints require
+`allow_insecure_dev=True`. Credentials belong in typed fields or secret-managed settings, never
+in broker URLs or examples.
 
 ### Handler Middleware
 
@@ -66,16 +92,27 @@ wrapped = chain_handlers(base, dedup(DedupConfig(window_size=100, ttl=60.0)))
 - **ManagedProducer / ManagedConsumer** — Lifecycle wrappers with metrics and graceful shutdown
 - **MessageRouter** — Topic-based handler dispatch with fnmatch wildcard patterns
 - **BatchProducer** — Collects and flushes messages in size/time/byte-triggered batches
-- **KafkaProducer / KafkaConsumer / KafkaComponent** — Concrete Kafka implementation using aiokafka
-- **InMemoryBroker** — In-memory broker for testing with assertion helpers
+- **KafkaProducer / KafkaConsumer / KafkaComponent** — Optional Kafka implementation using aiokafka
+- **NatsProducer / NatsConsumer** — Optional core NATS subject implementation using nats-py
+- **RabbitMqProducer / RabbitMqConsumer** — Optional RabbitMQ implementation using aio-pika
+- **InMemoryBroker** — In-memory broker for testing with bounded queues/history and assertion helpers
+- **DeadLetterProducer / DeadLetterEnvelope** — Opt-in DLQ routing with canonical `original_topic`, `error`, `retry_count`, `timestamp`, `headers`, and `payload` fields plus redaction
 - **DedupHandler / CircuitBreakerHandler** — Middleware for deduplication and circuit breaking
 - **chain_handlers()** — Compose middleware around a base handler
 - **assert_published() / wait_for_message()** — Test assertion helpers
 
+`MemoryConfig.history_limit` bounds recorded assertion history (default `1024`) and `MemoryConfig.max_brokers`
+bounds registry-owned in-memory brokers (default `32`). Use `clear_memory_brokers(registry)` in tests to
+drop registry-owned brokers between scenarios.
+
 ## Dependencies
 
 - `pykit-errors`, `pykit-component`
-- Optional: `aiokafka` (kafka extra), `pykit-provider`, `pykit-pipeline`, `pykit-dag`, `pykit-worker` (bridges extra)
+- Optional and isolated by extra: `aiokafka` (kafka), `nats-py` (nats), `aio-pika` (rabbitmq), `pykit-provider`, `pykit-pipeline`, `pykit-dag`, `pykit-worker` (bridges)
+
+## Validation
+
+Focused documentation checks verify that examples avoid hardcoded credentials and that core docs describe NATS/RabbitMQ as real opt-in adapters. Full validation counts belong to the CI/validation pass and are not claimed here.
 
 ## See Also
 

--- a/packages/pykit-messaging/README.md
+++ b/packages/pykit-messaging/README.md
@@ -60,9 +60,9 @@ await producer.send("events", b'{"action": "click"}', key="user-1")
 
 ### Configuration model
 
-`BrokerConfig` contains only broker-neutral policy: backend selection, name/enabled flags,
+`BrokerConfig` contains only broker-neutral policy: adapter selection, name/enabled flags,
 delivery guarantee, commit strategy, DLQ policy, retry/request timeout settings,
-`max_in_flight`, `consumer_group`, and backend-neutral `topics`/`subscriptions`. Broker
+`max_in_flight`, `consumer_group`, and adapter-neutral `topics`/`subscriptions`. Broker
 endpoints, protocol security credentials, batching, compression, routing/exchange details,
 and adapter-specific timeouts live in adapter configs such as `KafkaConfig`, `NatsConfig`,
 `RabbitMqConfig`, and `MemoryConfig`. Kafka, NATS, and RabbitMQ SDKs stay isolated behind

--- a/packages/pykit-messaging/README.md
+++ b/packages/pykit-messaging/README.md
@@ -71,10 +71,10 @@ optional extras; core and memory imports do not pull optional SDKs into the runt
 Factories validate creation-time config. Unsupported shared semantics are rejected with
 `AppError` instead of being silently ignored; for example, core NATS subjects reject ack-based
 at-least-once/exactly-once settings, RabbitMQ requires `auto_ack` to match `commit_strategy`,
-and Kafka exactly-once delivery requires a `transactional_id`. Secure connection settings are
-the default (`SSL`, `tls://`, `amqps://`); plaintext development endpoints require
-`allow_insecure_dev=True`. Credentials belong in typed fields or secret-managed settings, never
-in broker URLs or examples.
+and Kafka does not support exactly-once delivery (at-least-once is the maximum guarantee).
+Secure connection settings are the default (`SSL`, `tls://`, `amqps://`); plaintext development
+endpoints require `allow_insecure_dev=True`. Credentials belong in typed fields or secret-managed
+settings, never in broker URLs or examples.
 
 ### Handler Middleware
 

--- a/packages/pykit-messaging/pyproject.toml
+++ b/packages/pykit-messaging/pyproject.toml
@@ -10,11 +10,14 @@ dependencies = [
     "pykit-errors",
     "pykit-component",
     "pykit-util",
+    "pykit-resilience",
     "pykit-observability",
 ]
 
 [project.optional-dependencies]
 kafka = ["aiokafka", "cramjam"]
+nats = ["nats-py>=2.10"]
+rabbitmq = ["aio-pika>=9.5"]
 bridges = ["pykit-provider", "pykit-pipeline", "pykit-dag", "pykit-worker"]
 
 [build-system]

--- a/packages/pykit-messaging/src/pykit_messaging/__init__.py
+++ b/packages/pykit-messaging/src/pykit_messaging/__init__.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 from pykit_messaging.batch import BatchConfig, BatchProducer
-from pykit_messaging.config import BrokerConfig
+from pykit_messaging.config import BrokerConfig, CommitStrategy, DeliveryGuarantee, DLQPolicy
 from pykit_messaging.errors import ErrorClassifier
 from pykit_messaging.event_publisher import EventPublisher
 from pykit_messaging.handler import FuncHandler, HandlerMiddleware, MessageHandlerProtocol, chain_handlers
 from pykit_messaging.managed_consumer import ManagedConsumer
 from pykit_messaging.managed_producer import ManagedProducer
+from pykit_messaging.memory import (
+    InMemoryBroker,
+    InMemoryConsumer,
+    InMemoryProducer,
+    MemoryConfig,
+    clear_memory_brokers,
+)
 from pykit_messaging.metrics import MetricsCollector, NoopMetrics
 from pykit_messaging.middleware import (
     CircuitBreakerConfig,
@@ -26,12 +33,13 @@ from pykit_messaging.middleware import (
     instrument,
     retry,
 )
-from pykit_messaging.protocols import MessageConsumer, MessageProducer
+from pykit_messaging.protocols import ControllableConsumer, MessageConsumer, MessageProducer
+from pykit_messaging.registry import MessagingRegistry
 from pykit_messaging.router import MessageRouter
 from pykit_messaging.runner import ConsumerRunner
 from pykit_messaging.testing import assert_no_messages, assert_published, assert_published_n, wait_for_message
 from pykit_messaging.translator import JsonTranslator, MessageTranslator
-from pykit_messaging.types import Event, EventHandler, Message, MessageHandler
+from pykit_messaging.types import Event, EventHandler, JsonValue, Message, MessageHandler
 
 __all__ = [
     "BatchConfig",
@@ -40,8 +48,12 @@ __all__ = [
     "CircuitBreakerConfig",
     "CircuitBreakerHandler",
     "ConsumerRunner",
+    "ControllableConsumer",
+    "CommitStrategy",
     "DeadLetterConfig",
     "DeadLetterProducer",
+    "DeliveryGuarantee",
+    "DLQPolicy",
     "DedupConfig",
     "DedupHandler",
     "ErrorClassifier",
@@ -50,9 +62,14 @@ __all__ = [
     "EventPublisher",
     "FuncHandler",
     "HandlerMiddleware",
+    "InMemoryBroker",
+    "InMemoryConsumer",
+    "InMemoryProducer",
     "JsonTranslator",
+    "JsonValue",
     "ManagedConsumer",
     "ManagedProducer",
+    "MemoryConfig",
     "Message",
     "MessageConsumer",
     "MessageHandler",
@@ -60,6 +77,7 @@ __all__ = [
     "MessageProducer",
     "MessageRouter",
     "MessageTranslator",
+    "MessagingRegistry",
     "MetricsCollector",
     "MetricsHandler",
     "NoopMetrics",
@@ -71,6 +89,7 @@ __all__ = [
     "assert_published_n",
     "chain_handlers",
     "circuit_breaker",
+    "clear_memory_brokers",
     "dedup",
     "instrument",
     "retry",

--- a/packages/pykit-messaging/src/pykit_messaging/bridge/provider.py
+++ b/packages/pykit-messaging/src/pykit_messaging/bridge/provider.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from typing import Any
 
 from pykit_messaging.protocols import MessageConsumer, MessageProducer
 from pykit_messaging.types import Message
@@ -64,7 +63,7 @@ class _ConsumerBoxIterator(BoxIterator[Message]):
     def __init__(self, consumer: MessageConsumer) -> None:
         self._consumer = consumer
         self._queue: asyncio.Queue[Message | None] = asyncio.Queue()
-        self._task: asyncio.Task[Any] | None = None
+        self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
         """Start the background consume loop."""

--- a/packages/pykit-messaging/src/pykit_messaging/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/config.py
@@ -82,6 +82,11 @@ class BrokerConfig:
             self.commit_strategy = CommitStrategy(self.commit_strategy)
         except ValueError as exc:
             raise AppError.invalid_input("commit_strategy", "unsupported commit strategy") from exc
+        if self.commit_strategy is CommitStrategy.MANUAL:
+            raise AppError.invalid_input(
+                "commit_strategy",
+                "manual commits require an explicit ack/commit API and are not supported yet",
+            )
         return self
 
     def validate(self) -> None:

--- a/packages/pykit-messaging/src/pykit_messaging/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/config.py
@@ -43,15 +43,15 @@ class DLQPolicy:
 
 @dataclass
 class BrokerConfig:
-    """Base configuration shared by all broker backends.
+    """Base configuration shared by all broker adapters.
 
     Core config intentionally contains only broker-neutral policy, including
-    topic/subscription names when a caller wants a backend-neutral selection.
+    topic/subscription names when a caller wants an adapter-neutral selection.
     Adapter modules own connection endpoints, protocol security, batching, and
     broker-specific timeouts.
     """
 
-    backend: str = "memory"
+    adapter: str = "memory"
     name: str = ""
     enabled: bool = True
     delivery_guarantee: DeliveryGuarantee = DeliveryGuarantee.AT_LEAST_ONCE
@@ -71,8 +71,8 @@ class BrokerConfig:
 
     def apply_defaults(self) -> Self:
         """Normalize broker-neutral default values in-place and return ``self``."""
-        self.backend = self.backend.strip()
-        self.name = self.name.strip() or self.backend
+        self.adapter = self.adapter.strip()
+        self.name = self.name.strip() or self.adapter
         self.consumer_group = self.consumer_group.strip()
         try:
             self.delivery_guarantee = DeliveryGuarantee(self.delivery_guarantee)
@@ -91,11 +91,11 @@ class BrokerConfig:
 
     def validate(self) -> None:
         """Validate broker-neutral configuration fields."""
-        if not self.backend:
-            raise AppError.invalid_input("backend", "messaging backend name is required")
-        if not _NAME_RE.fullmatch(self.backend):
+        if not self.adapter:
+            raise AppError.invalid_input("adapter", "messaging adapter name is required")
+        if not _NAME_RE.fullmatch(self.adapter):
             raise AppError.invalid_input(
-                "backend", "messaging backend must contain only letters, digits, ., _, or -"
+                "adapter", "messaging adapter must contain only letters, digits, ., _, or -"
             )
         if not _NAME_RE.fullmatch(self.name):
             raise AppError.invalid_input(
@@ -119,12 +119,12 @@ class BrokerConfig:
             )
 
 
-def reject_exactly_once(config: BrokerConfig, backend: str) -> None:
-    """Raise a typed config error when *backend* cannot provide exactly-once delivery."""
+def reject_exactly_once(config: BrokerConfig, adapter: str) -> None:
+    """Raise a typed config error when *adapter* cannot provide exactly-once delivery."""
     if config.delivery_guarantee is DeliveryGuarantee.EXACTLY_ONCE:
         raise AppError.invalid_input(
             "delivery_guarantee",
-            f"{backend} does not support exactly-once delivery with this adapter",
+            f"{adapter} does not support exactly-once delivery with this adapter",
         )
 
 

--- a/packages/pykit-messaging/src/pykit_messaging/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/config.py
@@ -1,16 +1,142 @@
-"""Broker-agnostic configuration base."""
+"""Broker-agnostic messaging configuration."""
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Self
+
+from pykit_errors import AppError
+
+_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_TOPIC_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+
+class DeliveryGuarantee(StrEnum):
+    """Requested broker delivery semantics."""
+
+    AT_MOST_ONCE = "at_most_once"
+    AT_LEAST_ONCE = "at_least_once"
+    EXACTLY_ONCE = "exactly_once"
+
+
+class CommitStrategy(StrEnum):
+    """Offset/ack commit behavior."""
+
+    AUTO = "auto"
+    POST_HANDLER_SUCCESS = "post_handler_success"
+    MANUAL = "manual"
+
+
+@dataclass(frozen=True)
+class DLQPolicy:
+    """Dead-letter queue policy shared across broker adapters."""
+
+    enabled: bool = True
+    suffix: str = ".dlq"
+
+    def __post_init__(self) -> None:
+        if self.enabled and not self.suffix:
+            raise AppError.invalid_input("dlq.suffix", "DLQ suffix is required when DLQ is enabled")
 
 
 @dataclass
 class BrokerConfig:
-    """Base configuration shared by all broker backends."""
+    """Base configuration shared by all broker backends.
 
+    Core config intentionally contains only broker-neutral policy, including
+    topic/subscription names when a caller wants a backend-neutral selection.
+    Adapter modules own connection endpoints, protocol security, batching, and
+    broker-specific timeouts.
+    """
+
+    backend: str = "memory"
     name: str = ""
     enabled: bool = True
-    brokers: list[str] = field(default_factory=list)
+    delivery_guarantee: DeliveryGuarantee = DeliveryGuarantee.AT_LEAST_ONCE
+    commit_strategy: CommitStrategy = CommitStrategy.POST_HANDLER_SUCCESS
+    dlq: DLQPolicy = field(default_factory=DLQPolicy)
+    max_in_flight: int = 1
+    consumer_group: str = ""
+    topics: list[str] = field(default_factory=list)
+    subscriptions: list[str] = field(default_factory=list)
     retries: int = 3
     request_timeout_ms: int = 30000
+    retry_backoff_ms: int = 100
+
+    def __post_init__(self) -> None:
+        self.apply_defaults()
+        self.validate()
+
+    def apply_defaults(self) -> Self:
+        """Normalize broker-neutral default values in-place and return ``self``."""
+        self.backend = self.backend.strip()
+        self.name = self.name.strip() or self.backend
+        self.consumer_group = self.consumer_group.strip()
+        try:
+            self.delivery_guarantee = DeliveryGuarantee(self.delivery_guarantee)
+        except ValueError as exc:
+            raise AppError.invalid_input("delivery_guarantee", "unsupported delivery guarantee") from exc
+        try:
+            self.commit_strategy = CommitStrategy(self.commit_strategy)
+        except ValueError as exc:
+            raise AppError.invalid_input("commit_strategy", "unsupported commit strategy") from exc
+        return self
+
+    def validate(self) -> None:
+        """Validate broker-neutral configuration fields."""
+        if not self.backend:
+            raise AppError.invalid_input("backend", "messaging backend name is required")
+        if not _NAME_RE.fullmatch(self.backend):
+            raise AppError.invalid_input(
+                "backend", "messaging backend must contain only letters, digits, ., _, or -"
+            )
+        if not _NAME_RE.fullmatch(self.name):
+            raise AppError.invalid_input(
+                "name", "messaging config name must contain only letters, digits, ., _, or -"
+            )
+        if self.max_in_flight < 1:
+            raise AppError.invalid_input("max_in_flight", "max_in_flight must be at least 1")
+        for topic in self.topics:
+            validate_topic_name(topic, "topics")
+        for subscription in self.subscriptions:
+            validate_topic_name(subscription, "subscriptions")
+        if self.consumer_group:
+            validate_topic_name(self.consumer_group, "consumer_group")
+        if self.retries < 0:
+            raise AppError.invalid_input("retries", "retries must be greater than or equal to 0")
+        if self.request_timeout_ms < 1:
+            raise AppError.invalid_input("request_timeout_ms", "request_timeout_ms must be at least 1")
+        if self.retry_backoff_ms < 0:
+            raise AppError.invalid_input(
+                "retry_backoff_ms", "retry_backoff_ms must be greater than or equal to 0"
+            )
+
+
+def reject_exactly_once(config: BrokerConfig, backend: str) -> None:
+    """Raise a typed config error when *backend* cannot provide exactly-once delivery."""
+    if config.delivery_guarantee is DeliveryGuarantee.EXACTLY_ONCE:
+        raise AppError.invalid_input(
+            "delivery_guarantee",
+            f"{backend} does not support exactly-once delivery with this adapter",
+        )
+
+
+def _validate_topic_like(field: str, value: str) -> None:
+    if not value or any(ch.isspace() or ord(ch) < 32 for ch in value):
+        raise AppError.invalid_input(
+            field, f"{field} entries must not be empty or contain whitespace/control characters"
+        )
+
+
+def validate_topic_name(value: str, field: str = "topic") -> None:
+    """Validate broker-neutral topic, subject, queue, and group names."""
+    if not value or not value.strip():
+        raise AppError.invalid_input(field, f"{field} is required")
+    if len(value) > 249:
+        raise AppError.invalid_input(field, f"{field} must be at most 249 bytes")
+    if not _TOPIC_RE.fullmatch(value):
+        raise AppError.invalid_input(field, f"{field} must contain only letters, digits, ., _, -, or :")
+    if ".." in value:
+        raise AppError.invalid_input(field, f"{field} must not contain empty path segments")

--- a/packages/pykit-messaging/src/pykit_messaging/event_publisher.py
+++ b/packages/pykit-messaging/src/pykit_messaging/event_publisher.py
@@ -15,10 +15,8 @@ Example::
 
 from __future__ import annotations
 
-from typing import Any
-
 from pykit_messaging.protocols import MessageProducer
-from pykit_messaging.types import Event
+from pykit_messaging.types import Event, JsonValue
 
 
 class EventPublisher:
@@ -40,7 +38,7 @@ class EventPublisher:
         self,
         topic: str,
         event_type: str,
-        data: Any = None,
+        data: JsonValue = None,
     ) -> None:
         """Publish *data* as a domain event.
 
@@ -54,7 +52,7 @@ class EventPublisher:
         self,
         topic: str,
         event_type: str,
-        data: Any,
+        data: JsonValue,
         key: str,
     ) -> None:
         """Publish *data* with an explicit partition key.
@@ -69,7 +67,7 @@ class EventPublisher:
         self,
         topic: str,
         event_type: str,
-        items: list[Any],
+        items: list[JsonValue],
     ) -> None:
         """Publish multiple items, each wrapped in its own event envelope."""
         for item in items:

--- a/packages/pykit-messaging/src/pykit_messaging/event_publisher.py
+++ b/packages/pykit-messaging/src/pykit_messaging/event_publisher.py
@@ -57,7 +57,7 @@ class EventPublisher:
     ) -> None:
         """Publish *data* with an explicit partition key.
 
-        Sets ``Event.subject`` to *key* so messaging backends can use it
+        Sets ``Event.subject`` to *key* so messaging adapters can use it
         for ordering guarantees.
         """
         event = Event(type=event_type, source=self._source, subject=key, data=data)

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/__init__.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import fields
+
+from pykit_messaging.config import BrokerConfig
 from pykit_messaging.kafka.component import KafkaComponent
 from pykit_messaging.kafka.config import KafkaConfig
 from pykit_messaging.kafka.consumer import KafkaConsumer
@@ -15,6 +18,22 @@ from pykit_messaging.kafka.middleware import (
     TracingHandler,
 )
 from pykit_messaging.kafka.producer import KafkaProducer
+from pykit_messaging.registry import MessagingRegistry
+
+
+def register(registry: MessagingRegistry) -> None:
+    """Register Kafka producer and consumer factories."""
+    registry.register_producer("kafka", lambda config: KafkaProducer(_config_from(config)))
+    registry.register_consumer("kafka", lambda config: KafkaConsumer(_config_from(config)))
+
+
+def _config_from(config: BrokerConfig) -> KafkaConfig:
+    if isinstance(config, KafkaConfig):
+        config.validate()
+        return config
+    allowed = {field.name for field in fields(KafkaConfig)}
+    return KafkaConfig(**{key: value for key, value in config.__dict__.items() if key in allowed})
+
 
 __all__ = [
     "DeadLetterEnvelope",
@@ -28,6 +47,7 @@ __all__ = [
     "RetryHandler",
     "RetryMiddlewareConfig",
     "TracingHandler",
+    "register",
     "is_connection_error",
     "is_retryable_error",
 ]

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/config.py
@@ -21,7 +21,7 @@ _ACKS = {"0", "1", "all"}
 class KafkaConfig(BrokerConfig):
     """Configuration for the Kafka adapter."""
 
-    backend: str = "kafka"
+    adapter: str = "kafka"
     name: str = "kafka"
 
     # Kafka connection and subscription settings.

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/config.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from pykit_errors import AppError
-from pykit_messaging.config import BrokerConfig, CommitStrategy, DeliveryGuarantee, validate_topic_name
+from pykit_messaging.config import (
+    BrokerConfig,
+    reject_exactly_once,
+    validate_topic_name,
+)
 
 _SECURITY_PROTOCOLS = {"PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"}
 _COMPRESSION_TYPES = {"gzip", "snappy", "lz4", "zstd", "none"}
@@ -98,17 +102,7 @@ class KafkaConfig(BrokerConfig):
             )
         if self.max_poll_records is not None and self.max_poll_records < 1:
             raise AppError.invalid_input("max_poll_records", "max_poll_records must be at least 1")
-        if self.delivery_guarantee is DeliveryGuarantee.EXACTLY_ONCE and not self.transactional_id:
-            raise AppError.invalid_input(
-                "transactional_id", "Kafka exactly-once delivery requires a transactional_id"
-            )
-        if (
-            self.delivery_guarantee is DeliveryGuarantee.EXACTLY_ONCE
-            and self.commit_strategy is CommitStrategy.AUTO
-        ):
-            raise AppError.invalid_input(
-                "commit_strategy", "Kafka exactly-once delivery requires post-handler or manual commits"
-            )
+        reject_exactly_once(self, "kafka")
 
 
 def _has_url_credentials(value: str) -> bool:

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/config.py
@@ -4,38 +4,116 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from pykit_messaging.config import BrokerConfig
+from pykit_errors import AppError
+from pykit_messaging.config import BrokerConfig, CommitStrategy, DeliveryGuarantee, validate_topic_name
+
+_SECURITY_PROTOCOLS = {"PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"}
+_COMPRESSION_TYPES = {"gzip", "snappy", "lz4", "zstd", "none"}
+_OFFSET_RESETS = {"earliest", "latest", "none"}
+_ACKS = {"0", "1", "all"}
 
 
 @dataclass
 class KafkaConfig(BrokerConfig):
-    """Configuration for Kafka producer/consumer.
+    """Configuration for the Kafka adapter."""
 
-    Inherits :class:`~pykit_messaging.config.BrokerConfig` fields
-    (``name``, ``enabled``, ``brokers``, ``retries``, ``request_timeout_ms``)
-    and adds Kafka-specific settings.
-    """
-
-    # Override defaults for Kafka
+    backend: str = "kafka"
     name: str = "kafka"
-    brokers: list[str] = field(default_factory=lambda: ["localhost:9092"])
 
-    # Kafka-specific fields
+    # Kafka connection and subscription settings.
+    brokers: list[str] = field(default_factory=lambda: ["localhost:9092"])
     group_id: str = ""
     topics: list[str] = field(default_factory=list)
 
-    # Security
-    security_protocol: str = "PLAINTEXT"
+    # Security.
+    security_protocol: str = "SSL"
     sasl_mechanism: str = ""
-    sasl_username: str = ""
-    sasl_password: str = ""
+    sasl_username: str = field(default="", repr=False)
+    sasl_password: str = field(default="", repr=False)
+    ssl_context: object | None = field(default=None, repr=False)
+    allow_insecure_dev: bool = False
 
-    # Producer settings
+    # Producer settings.
     compression_type: str = "snappy"
     max_batch_size: int = 16384
-    retry_backoff_ms: int = 100
+    linger_ms: int = 0
+    acks: str = "all"
+    enable_idempotence: bool = True
+    transactional_id: str = field(default="", repr=False)
 
-    # Consumer settings
+    # Consumer settings.
     session_timeout_ms: int = 30000
     heartbeat_interval_ms: int = 3000
     auto_offset_reset: str = "earliest"
+    max_poll_records: int | None = None
+
+    def validate(self) -> None:
+        """Validate Kafka-specific and broker-neutral settings."""
+        super().validate()
+        if self.consumer_group and self.group_id and self.consumer_group != self.group_id:
+            raise AppError.invalid_input(
+                "consumer_group", "consumer_group and group_id must match when both are set"
+            )
+        if not self.brokers:
+            raise AppError.invalid_input("brokers", "at least one Kafka bootstrap broker is required")
+        if any(not broker.strip() for broker in self.brokers):
+            raise AppError.invalid_input("brokers", "Kafka broker addresses must be non-empty")
+        if any(_has_url_credentials(broker) or "?" in broker for broker in self.brokers):
+            raise AppError.invalid_input(
+                "brokers", "Kafka broker addresses must not contain credentials or query strings"
+            )
+        for topic in self.topics:
+            validate_topic_name(topic, "topics")
+        if self.group_id:
+            validate_topic_name(self.group_id, "group_id")
+        if self.security_protocol not in _SECURITY_PROTOCOLS:
+            raise AppError.invalid_input("security_protocol", "unsupported Kafka security protocol")
+        if self.security_protocol in {"PLAINTEXT", "SASL_PLAINTEXT"} and not self.allow_insecure_dev:
+            raise AppError.invalid_input(
+                "security_protocol", "Kafka plaintext protocols require allow_insecure_dev=True"
+            )
+        if self.security_protocol.startswith("SASL") and not self.sasl_mechanism:
+            raise AppError.invalid_input("sasl_mechanism", "SASL Kafka connections require a mechanism")
+        if self.sasl_mechanism and (not self.sasl_username or not self.sasl_password):
+            raise AppError.invalid_input(
+                "sasl_credentials", "SASL Kafka connections require username and password"
+            )
+        if self.compression_type not in _COMPRESSION_TYPES:
+            raise AppError.invalid_input("compression_type", "unsupported Kafka compression type")
+        if self.max_batch_size < 1:
+            raise AppError.invalid_input("max_batch_size", "max_batch_size must be at least 1")
+        if self.linger_ms < 0:
+            raise AppError.invalid_input("linger_ms", "linger_ms must be greater than or equal to 0")
+        if self.acks not in _ACKS:
+            raise AppError.invalid_input("acks", "Kafka acks must be one of 0, 1, or all")
+        if self.auto_offset_reset not in _OFFSET_RESETS:
+            raise AppError.invalid_input("auto_offset_reset", "unsupported Kafka auto_offset_reset")
+        if self.session_timeout_ms < 1:
+            raise AppError.invalid_input("session_timeout_ms", "session_timeout_ms must be at least 1")
+        if self.heartbeat_interval_ms < 1:
+            raise AppError.invalid_input("heartbeat_interval_ms", "heartbeat_interval_ms must be at least 1")
+        if self.heartbeat_interval_ms >= self.session_timeout_ms:
+            raise AppError.invalid_input(
+                "heartbeat_interval_ms", "heartbeat_interval_ms must be less than session_timeout_ms"
+            )
+        if self.max_poll_records is not None and self.max_poll_records < 1:
+            raise AppError.invalid_input("max_poll_records", "max_poll_records must be at least 1")
+        if self.delivery_guarantee is DeliveryGuarantee.EXACTLY_ONCE and not self.transactional_id:
+            raise AppError.invalid_input(
+                "transactional_id", "Kafka exactly-once delivery requires a transactional_id"
+            )
+        if (
+            self.delivery_guarantee is DeliveryGuarantee.EXACTLY_ONCE
+            and self.commit_strategy is CommitStrategy.AUTO
+        ):
+            raise AppError.invalid_input(
+                "commit_strategy", "Kafka exactly-once delivery requires post-handler or manual commits"
+            )
+
+
+def _has_url_credentials(value: str) -> bool:
+    marker = "://"
+    if marker not in value:
+        return False
+    authority = value.split(marker, 1)[1].split("/", 1)[0].split("?", 1)[0].split("#", 1)[0]
+    return "@" in authority

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/consumer.py
@@ -6,7 +6,8 @@ import asyncio
 import contextlib
 import importlib
 import logging
-from typing import Protocol
+from collections.abc import AsyncIterator, Callable
+from typing import Protocol, cast
 
 from pykit_messaging.kafka.config import KafkaConfig
 from pykit_messaging.types import Event, EventHandler, Message, MessageHandler
@@ -33,14 +34,17 @@ class _KafkaConsumerClient(Protocol):
 
     async def commit(self) -> object: ...
 
-    def __aiter__(self) -> object: ...
+    def __aiter__(self) -> AsyncIterator[_KafkaConsumerRecord]: ...
 
 
 class _KafkaErrorFallback(Exception):
     pass
 
 
-AIOKafkaConsumer: object | None = None
+_KafkaConsumerFactory = Callable[..., _KafkaConsumerClient]
+
+
+AIOKafkaConsumer: _KafkaConsumerFactory | None = None
 KafkaError: type[Exception] = _KafkaErrorFallback
 KafkaConnectionError: type[Exception] = _KafkaErrorFallback
 
@@ -55,9 +59,9 @@ def _load_aiokafka() -> None:
     except ImportError as exc:
         msg = "aiokafka is required for Kafka messaging; install pykit-messaging[kafka]"
         raise ImportError(msg) from exc
-    AIOKafkaConsumer = aiokafka.AIOKafkaConsumer
-    KafkaError = aiokafka_errors.KafkaError
-    KafkaConnectionError = aiokafka_errors.KafkaConnectionError
+    AIOKafkaConsumer = cast("_KafkaConsumerFactory", aiokafka.AIOKafkaConsumer)
+    KafkaError = cast("type[Exception]", aiokafka_errors.KafkaError)
+    KafkaConnectionError = cast("type[Exception]", aiokafka_errors.KafkaConnectionError)
 
 
 _MAX_START_RETRIES = 30

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/consumer.py
@@ -4,16 +4,61 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import importlib
 import logging
-from typing import Any
-
-from aiokafka import AIOKafkaConsumer  # type: ignore[import-untyped]
-from aiokafka.errors import KafkaConnectionError, KafkaError  # type: ignore[import-untyped]
+from typing import Protocol
 
 from pykit_messaging.kafka.config import KafkaConfig
 from pykit_messaging.types import Event, EventHandler, Message, MessageHandler
+from pykit_resilience import RetryConfig, RetryExhaustedError, calculate_backoff, retry
 
 logger = logging.getLogger(__name__)
+
+
+class _KafkaConsumerRecord(Protocol):
+    key: bytes | None
+    value: bytes
+    topic: str
+    partition: int
+    offset: int
+    headers: list[tuple[str | bytes, bytes]] | None
+
+
+class _KafkaConsumerClient(Protocol):
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+    def subscribe(self, topics: list[str]) -> object: ...
+
+    async def commit(self) -> object: ...
+
+    def __aiter__(self) -> object: ...
+
+
+class _KafkaErrorFallback(Exception):
+    pass
+
+
+AIOKafkaConsumer: object | None = None
+KafkaError: type[Exception] = _KafkaErrorFallback
+KafkaConnectionError: type[Exception] = _KafkaErrorFallback
+
+
+def _load_aiokafka() -> None:
+    global AIOKafkaConsumer, KafkaConnectionError, KafkaError
+    if AIOKafkaConsumer is not None:
+        return
+    try:
+        aiokafka = importlib.import_module("aiokafka")
+        aiokafka_errors = importlib.import_module("aiokafka.errors")
+    except ImportError as exc:
+        msg = "aiokafka is required for Kafka messaging; install pykit-messaging[kafka]"
+        raise ImportError(msg) from exc
+    AIOKafkaConsumer = aiokafka.AIOKafkaConsumer
+    KafkaError = aiokafka_errors.KafkaError
+    KafkaConnectionError = aiokafka_errors.KafkaConnectionError
+
 
 _MAX_START_RETRIES = 30
 _START_BACKOFF_BASE = 1.0
@@ -25,20 +70,25 @@ class KafkaConsumer:
 
     def __init__(self, config: KafkaConfig) -> None:
         self._config = config
-        self._consumer: AIOKafkaConsumer | None = None
+        self._consumer: _KafkaConsumerClient | None = None
         self._stopped = False
 
-    def _build_kwargs(self) -> dict[str, Any]:
+    def _build_kwargs(self) -> dict[str, object]:
         cfg = self._config
-        kwargs: dict[str, Any] = {
+        kwargs: dict[str, object] = {
             "bootstrap_servers": ",".join(cfg.brokers),
-            "group_id": cfg.group_id or None,
+            "group_id": cfg.consumer_group or cfg.group_id or None,
             "auto_offset_reset": cfg.auto_offset_reset,
             "session_timeout_ms": cfg.session_timeout_ms,
             "heartbeat_interval_ms": cfg.heartbeat_interval_ms,
             "security_protocol": cfg.security_protocol,
-            "enable_auto_commit": False,
+            "enable_auto_commit": cfg.commit_strategy.value == "auto",
+            "request_timeout_ms": cfg.request_timeout_ms,
+            "retry_backoff_ms": cfg.retry_backoff_ms,
         }
+        kwargs["max_poll_records"] = cfg.max_poll_records or cfg.max_in_flight
+        if cfg.ssl_context is not None:
+            kwargs["ssl_context"] = cfg.ssl_context
         if cfg.sasl_mechanism:
             kwargs["sasl_mechanism"] = cfg.sasl_mechanism
             kwargs["sasl_plain_username"] = cfg.sasl_username
@@ -47,49 +97,81 @@ class KafkaConsumer:
 
     async def start(self) -> None:
         """Create and start the underlying AIOKafkaConsumer with retry."""
+        _load_aiokafka()
         self._stopped = False
         cfg = self._config
         kwargs = self._build_kwargs()
-        topics_str = ", ".join(cfg.topics) if cfg.topics else "(none)"
+        topics = cfg.subscriptions or cfg.topics
+        topics_str = ", ".join(topics) if topics else "(none)"
 
-        for attempt in range(1, _MAX_START_RETRIES + 1):
+        def _on_retry(attempt: int, _exc: Exception, _backoff: float) -> None:
+            if attempt == 1:
+                logger.warning(
+                    "Kafka not ready, retrying connection (topics: %s)...",
+                    topics_str,
+                )
+
+        async def _start_once() -> None:
             try:
-                self._consumer = AIOKafkaConsumer(*cfg.topics, **kwargs)
+                consumer_factory = AIOKafkaConsumer
+                if consumer_factory is None:
+                    raise RuntimeError("aiokafka consumer factory was not loaded")
+                self._consumer = consumer_factory(*topics, **kwargs)
                 await self._consumer.start()
-                return
-            except Exception:
-                if attempt == _MAX_START_RETRIES:
-                    logger.error(
-                        "Kafka consumer failed to start after %d attempts (topics: %s)",
-                        _MAX_START_RETRIES,
-                        topics_str,
-                    )
-                    raise
-                backoff = min(_START_BACKOFF_BASE * (2 ** (attempt - 1)), _START_BACKOFF_MAX)
-                if attempt == 1:
-                    logger.warning(
-                        "Kafka not ready, retrying connection (topics: %s)...",
-                        topics_str,
-                    )
-                await asyncio.sleep(backoff)
+            except KafkaError:
+                if self._consumer is not None:
+                    with contextlib.suppress(KafkaError, RuntimeError):
+                        await self._consumer.stop()
+                    self._consumer = None
+                raise
+
+        try:
+            await retry(
+                _start_once,
+                RetryConfig(
+                    max_attempts=_MAX_START_RETRIES,
+                    initial_backoff=_START_BACKOFF_BASE,
+                    max_backoff=_START_BACKOFF_MAX,
+                    jitter=0.0,
+                    retry_if=lambda exc: isinstance(exc, KafkaError),
+                    on_retry=_on_retry,
+                ),
+            )
+        except RetryExhaustedError as exc:
+            logger.error(
+                "Kafka consumer failed to start after %d attempts (topics: %s)",
+                _MAX_START_RETRIES,
+                topics_str,
+            )
+            raise exc.last_error from exc
 
     async def _reconnect(self) -> None:
         """Stop current consumer and restart with backoff."""
-        topics_str = ", ".join(self._config.topics) if self._config.topics else "(none)"
+        topics = self._config.subscriptions or self._config.topics
+        topics_str = ", ".join(topics) if topics else "(none)"
         # Silently close old consumer
         if self._consumer is not None:
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(KafkaError, RuntimeError):
                 await self._consumer.stop()
             self._consumer = None
 
-        backoff = 1.0
+        attempt = 1
+        backoff_config = RetryConfig(
+            initial_backoff=1.0,
+            max_backoff=_START_BACKOFF_MAX,
+            jitter=0.0,
+        )
+        backoff = calculate_backoff(attempt, backoff_config)
         while not self._stopped:
             try:
-                self._consumer = AIOKafkaConsumer(*self._config.topics, **self._build_kwargs())
+                consumer_factory = AIOKafkaConsumer
+                if consumer_factory is None:
+                    raise RuntimeError("aiokafka consumer factory was not loaded")
+                self._consumer = consumer_factory(*topics, **self._build_kwargs())
                 await self._consumer.start()
                 logger.info("Kafka consumer reconnected (topics: %s)", topics_str)
                 return
-            except Exception:
+            except KafkaError:
                 if self._stopped:
                     return
                 logger.warning(
@@ -98,7 +180,8 @@ class KafkaConsumer:
                     topics_str,
                 )
                 await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, _START_BACKOFF_MAX)
+                attempt += 1
+                backoff = calculate_backoff(attempt, backoff_config)
 
     async def stop(self) -> None:
         """Stop the consumer."""
@@ -140,19 +223,14 @@ class KafkaConsumer:
                     )
                     await handler(msg)
 
-                    # Manual commit after successful processing
-                    with contextlib.suppress(KafkaError):
-                        await self._consumer.commit()
+                    if self._config.commit_strategy.value == "post_handler_success":
+                        with contextlib.suppress(KafkaError):
+                            await self._consumer.commit()
 
             except (KafkaConnectionError, KafkaError) as e:
                 if self._stopped:
                     return
                 logger.warning("Kafka connection lost (%s), reconnecting...", e)
-                await self._reconnect()
-            except Exception as e:
-                if self._stopped:
-                    return
-                logger.error("Unexpected consumer error: %s", e)
                 await self._reconnect()
 
     async def consume_events(self, handler: EventHandler) -> None:

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/middleware/deadletter.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/middleware/deadletter.py
@@ -1,66 +1,26 @@
-"""Dead-letter queue producer for failed messages."""
+"""Kafka dead-letter queue producer for failed messages.
+
+Kafka uses the canonical broker-agnostic DLQ envelope and redaction policy from
+``pykit_messaging.middleware.dead_letter``.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from datetime import UTC, datetime
-
+from pykit_messaging.middleware.dead_letter import (
+    DeadLetterConfig,
+    DeadLetterEnvelope,
+)
+from pykit_messaging.middleware.dead_letter import (
+    DeadLetterProducer as _CoreDeadLetterProducer,
+)
 from pykit_messaging.protocols import MessageProducer
-from pykit_messaging.types import Message
-from pykit_util import JsonCodec
 
 
-@dataclass
-class DeadLetterEnvelope:
-    """Envelope written to the DLQ topic."""
-
-    original_topic: str
-    error: str
-    retry_count: int
-    timestamp: str
-    headers: dict[str, str] = field(default_factory=dict)
-    payload: str = ""
-
-
-class DeadLetterProducer:
-    """Sends failed messages to a dead-letter queue topic.
-
-    The DLQ topic name is ``{original_topic}{suffix}`` where suffix
-    defaults to ``".dlq"``.
-    """
+class DeadLetterProducer(_CoreDeadLetterProducer):
+    """Kafka-compatible DLQ producer with the historic ``suffix=`` constructor."""
 
     def __init__(self, producer: MessageProducer, *, suffix: str = ".dlq") -> None:
-        self._producer = producer
-        self._suffix = suffix
+        super().__init__(producer, DeadLetterConfig(suffix=suffix))
 
-    async def send(self, msg: Message, error: Exception) -> None:
-        """Publish a dead-letter envelope for the failed message."""
-        retry_count = 0
-        rc = msg.headers.get("x-retry-count", "")
-        if rc.isdigit():
-            retry_count = int(rc)
 
-        envelope = DeadLetterEnvelope(
-            original_topic=msg.topic,
-            error=str(error),
-            retry_count=retry_count,
-            timestamp=datetime.now(UTC).isoformat(),
-            headers=dict(msg.headers),
-            payload=msg.value.decode(errors="replace"),
-        )
-
-        dlq_topic = msg.topic + self._suffix
-        key = msg.key or "dlq"
-
-        payload = JsonCodec[dict[str, object]]().encode(
-            {
-                "original_topic": envelope.original_topic,
-                "error": envelope.error,
-                "retry_count": envelope.retry_count,
-                "timestamp": envelope.timestamp,
-                "headers": envelope.headers,
-                "payload": envelope.payload,
-            }
-        )
-
-        await self._producer.send(dlq_topic, value=payload, key=key)
+__all__ = ["DeadLetterConfig", "DeadLetterEnvelope", "DeadLetterProducer"]

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/middleware/retry.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/middleware/retry.py
@@ -1,51 +1,33 @@
-"""Retry middleware for Kafka message handlers with exponential backoff."""
+"""Retry middleware for Kafka message handlers."""
 
 from __future__ import annotations
 
-import asyncio
-import math
-import random
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from pykit_messaging.types import Message, MessageHandler
+from pykit_resilience import RetryConfig as ResilienceRetryConfig
+from pykit_resilience import RetryExhaustedError
+from pykit_resilience import retry as retry_async
 
 
 @dataclass
-class RetryMiddlewareConfig:
+class RetryMiddlewareConfig(ResilienceRetryConfig):
     """Configuration for Kafka retry middleware."""
 
-    max_attempts: int = 3
-    initial_backoff: float = 0.1
-    max_backoff: float = 10.0
-    backoff_factor: float = 2.0
-    jitter: float = 0.1
-    retry_if: Callable[[Exception], bool] | None = None
     on_exhausted: Callable[[Message, Exception], Awaitable[None]] | None = None
 
 
-def _calculate_backoff(attempt: int, config: RetryMiddlewareConfig) -> float:
-    """Calculate backoff duration with exponential growth and jitter."""
-    backoff = config.initial_backoff * math.pow(config.backoff_factor, attempt - 1)
-    if config.jitter > 0:
-        jitter_range = backoff * config.jitter
-        backoff += random.uniform(-jitter_range, jitter_range)
-    backoff = min(backoff, config.max_backoff)
-    return max(backoff, 0.0)
-
-
 def RetryHandler(handler: MessageHandler, config: RetryMiddlewareConfig | None = None) -> MessageHandler:
-    """Wrap a MessageHandler with retry logic using exponential backoff.
+    """Wrap a MessageHandler with canonical retry behavior.
 
-    Each retry attempt updates the ``x-retry-count`` header on the message.
-    When all attempts are exhausted, ``config.on_exhausted`` is invoked
-    (e.g. for DLQ routing) and the last error is returned.
+    Each retry attempt updates the ``x-retry-count`` header on a cloned message.
     """
     cfg = config or RetryMiddlewareConfig()
 
     async def wrapper(msg: Message) -> None:
         headers = dict(msg.headers)
-        msg = Message(
+        cloned = Message(
             key=msg.key,
             value=msg.value,
             topic=msg.topic,
@@ -54,26 +36,20 @@ def RetryHandler(handler: MessageHandler, config: RetryMiddlewareConfig | None =
             timestamp=msg.timestamp,
             headers=headers,
         )
+        attempt = 0
 
-        last_error: Exception | None = None
-        for attempt in range(1, cfg.max_attempts + 1):
-            try:
-                if attempt > 1:
-                    msg.headers["x-retry-count"] = str(attempt - 1)
-                await handler(msg)
-                return
-            except Exception as exc:
-                last_error = exc
-                if cfg.retry_if is not None and not cfg.retry_if(exc):
-                    raise
-                if attempt < cfg.max_attempts:
-                    backoff = _calculate_backoff(attempt, cfg)
-                    await asyncio.sleep(backoff)
+        async def _handle() -> None:
+            nonlocal attempt
+            attempt += 1
+            if attempt > 1:
+                cloned.headers["x-retry-count"] = str(attempt - 1)
+            await handler(cloned)
 
-        if cfg.on_exhausted is not None and last_error is not None:
-            await cfg.on_exhausted(msg, last_error)
-
-        if last_error is not None:
-            raise last_error
+        try:
+            await retry_async(_handle, cfg)
+        except RetryExhaustedError as exc:
+            if cfg.on_exhausted is not None:
+                await cfg.on_exhausted(cloned, exc.last_error)
+            raise exc.last_error from exc
 
     return wrapper

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/producer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/producer.py
@@ -2,18 +2,58 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
+import importlib
 import logging
-from typing import Any
+from typing import Protocol
 
-from aiokafka import AIOKafkaProducer  # type: ignore[import-untyped]
-
+from pykit_messaging.config import validate_topic_name
 from pykit_messaging.kafka.config import KafkaConfig
-from pykit_messaging.types import Event, Message
+from pykit_messaging.types import Event, JsonValue, Message
+from pykit_resilience import RetryConfig, RetryExhaustedError, retry
 from pykit_util import JsonCodec
 
 logger = logging.getLogger(__name__)
+
+
+class _KafkaProducerClient(Protocol):
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+    async def send_and_wait(
+        self,
+        topic: str,
+        *,
+        value: bytes,
+        key: bytes | None = None,
+        headers: list[tuple[str, bytes]] | None = None,
+    ) -> object: ...
+
+    async def flush(self) -> None: ...
+
+
+class _KafkaErrorFallback(Exception):
+    pass
+
+
+AIOKafkaProducer: object | None = None
+KafkaError: type[Exception] = _KafkaErrorFallback
+
+
+def _load_aiokafka() -> None:
+    global AIOKafkaProducer, KafkaError
+    if AIOKafkaProducer is not None:
+        return
+    try:
+        aiokafka = importlib.import_module("aiokafka")
+        aiokafka_errors = importlib.import_module("aiokafka.errors")
+    except ImportError as exc:
+        msg = "aiokafka is required for Kafka messaging; install pykit-messaging[kafka]"
+        raise ImportError(msg) from exc
+    AIOKafkaProducer = aiokafka.AIOKafkaProducer
+    KafkaError = aiokafka_errors.KafkaError
+
 
 _MAX_START_RETRIES = 30
 _START_BACKOFF_BASE = 1.0
@@ -25,45 +65,69 @@ class KafkaProducer:
 
     def __init__(self, config: KafkaConfig) -> None:
         self._config = config
-        self._producer: AIOKafkaProducer | None = None
+        self._producer: _KafkaProducerClient | None = None
 
     async def start(self) -> None:
         """Create and start the underlying AIOKafkaProducer with retry."""
+        _load_aiokafka()
         cfg = self._config
-        kwargs: dict[str, Any] = {
+        kwargs: dict[str, object] = {
             "bootstrap_servers": ",".join(cfg.brokers),
             "compression_type": cfg.compression_type,
             "max_batch_size": cfg.max_batch_size,
             "request_timeout_ms": cfg.request_timeout_ms,
             "retry_backoff_ms": cfg.retry_backoff_ms,
             "security_protocol": cfg.security_protocol,
+            "linger_ms": cfg.linger_ms,
+            "acks": cfg.acks,
+            "enable_idempotence": cfg.enable_idempotence,
+            "max_in_flight_requests_per_connection": cfg.max_in_flight,
         }
+        if cfg.transactional_id:
+            kwargs["transactional_id"] = cfg.transactional_id
+        if cfg.ssl_context is not None:
+            kwargs["ssl_context"] = cfg.ssl_context
         if cfg.sasl_mechanism:
             kwargs["sasl_mechanism"] = cfg.sasl_mechanism
             kwargs["sasl_plain_username"] = cfg.sasl_username
             kwargs["sasl_plain_password"] = cfg.sasl_password
 
-        for attempt in range(1, _MAX_START_RETRIES + 1):
+        def _on_retry(attempt: int, _exc: Exception, _backoff: float) -> None:
+            if attempt == 1:
+                logger.warning("Kafka not ready, retrying producer connection...")
+
+        async def _start_once() -> None:
             try:
-                self._producer = AIOKafkaProducer(**kwargs)
+                producer_factory = AIOKafkaProducer
+                if producer_factory is None:
+                    raise RuntimeError("aiokafka producer factory was not loaded")
+                self._producer = producer_factory(**kwargs)
                 await self._producer.start()
-                return
-            except Exception:
-                # Clean up the failed producer to avoid "Unclosed AIOKafkaProducer" warnings
+            except KafkaError:
                 if self._producer is not None:
-                    with contextlib.suppress(Exception):
+                    with contextlib.suppress(KafkaError, RuntimeError):
                         await self._producer.stop()
                     self._producer = None
-                if attempt == _MAX_START_RETRIES:
-                    logger.error(
-                        "Kafka producer failed to start after %d attempts",
-                        _MAX_START_RETRIES,
-                    )
-                    raise
-                backoff = min(_START_BACKOFF_BASE * (2 ** (attempt - 1)), _START_BACKOFF_MAX)
-                if attempt == 1:
-                    logger.warning("Kafka not ready, retrying producer connection...")
-                await asyncio.sleep(backoff)
+                raise
+
+        try:
+            await retry(
+                _start_once,
+                RetryConfig(
+                    max_attempts=_MAX_START_RETRIES,
+                    initial_backoff=_START_BACKOFF_BASE,
+                    max_backoff=_START_BACKOFF_MAX,
+                    jitter=0.0,
+                    retry_if=lambda exc: isinstance(exc, KafkaError),
+                    on_retry=_on_retry,
+                ),
+            )
+        except RetryExhaustedError as exc:
+            logger.error(
+                "Kafka producer failed to start after %d attempts",
+                _MAX_START_RETRIES,
+            )
+            raise exc.last_error from exc
 
     async def stop(self) -> None:
         """Stop the producer."""
@@ -79,6 +143,7 @@ class KafkaProducer:
         headers: dict[str, str] | None = None,
     ) -> None:
         """Send a raw message to the given topic."""
+        validate_topic_name(topic, "topic")
         if self._producer is None:
             raise RuntimeError("Producer is not started")
 
@@ -102,9 +167,9 @@ class KafkaProducer:
             headers={"event-type": event.type},
         )
 
-    async def send_json(self, topic: str, data: Any, key: str | None = None) -> None:
+    async def send_json(self, topic: str, data: JsonValue, key: str | None = None) -> None:
         """Serialize *data* as JSON and send it."""
-        value = JsonCodec[Any](stringify_unknown=False).encode(data)
+        value = JsonCodec[JsonValue](stringify_unknown=False).encode(data)
         await self.send(topic, value=value, key=key)
 
     async def send_batch(self, messages: list[Message]) -> None:

--- a/packages/pykit-messaging/src/pykit_messaging/kafka/producer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/kafka/producer.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import contextlib
 import importlib
 import logging
-from typing import Protocol
+from collections.abc import Callable
+from typing import Protocol, cast
 
 from pykit_messaging.config import validate_topic_name
 from pykit_messaging.kafka.config import KafkaConfig
@@ -37,7 +38,10 @@ class _KafkaErrorFallback(Exception):
     pass
 
 
-AIOKafkaProducer: object | None = None
+_KafkaProducerFactory = Callable[..., _KafkaProducerClient]
+
+
+AIOKafkaProducer: _KafkaProducerFactory | None = None
 KafkaError: type[Exception] = _KafkaErrorFallback
 
 
@@ -51,8 +55,8 @@ def _load_aiokafka() -> None:
     except ImportError as exc:
         msg = "aiokafka is required for Kafka messaging; install pykit-messaging[kafka]"
         raise ImportError(msg) from exc
-    AIOKafkaProducer = aiokafka.AIOKafkaProducer
-    KafkaError = aiokafka_errors.KafkaError
+    AIOKafkaProducer = cast("_KafkaProducerFactory", aiokafka.AIOKafkaProducer)
+    KafkaError = cast("type[Exception]", aiokafka_errors.KafkaError)
 
 
 _MAX_START_RETRIES = 30

--- a/packages/pykit-messaging/src/pykit_messaging/managed_producer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/managed_producer.py
@@ -7,7 +7,7 @@ import time
 
 from pykit_messaging.metrics import MetricsCollector, NoopMetrics
 from pykit_messaging.protocols import MessageProducer
-from pykit_messaging.types import Event, Message
+from pykit_messaging.types import Event, JsonValue, Message
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ class ManagedProducer:
             duration_ms = (time.monotonic() - start) * 1000
             self._metrics.record_publish(topic, duration_ms, success=success)
 
-    async def send_json(self, topic: str, data: object, key: str | None = None) -> None:
+    async def send_json(self, topic: str, data: JsonValue, key: str | None = None) -> None:
         """Send JSON data, recording metrics.
 
         Args:

--- a/packages/pykit-messaging/src/pykit_messaging/memory.py
+++ b/packages/pykit-messaging/src/pykit_messaging/memory.py
@@ -18,7 +18,7 @@ from pykit_util import JsonCodec
 if TYPE_CHECKING:
     from pykit_messaging.registry import MessagingRegistry
 
-_BACKEND_NAME = "memory"
+_ADAPTER_NAME = "memory"
 _DEFAULT_CAPACITY = 256
 _DEFAULT_HISTORY_LIMIT = 1024
 _DEFAULT_MAX_BROKERS = 32
@@ -26,19 +26,19 @@ _DEFAULT_MAX_BROKERS = 32
 
 @dataclass
 class MemoryConfig(BrokerConfig):
-    """Configuration for the in-memory messaging backend."""
+    """Configuration for the in-memory messaging adapter."""
 
-    backend: str = _BACKEND_NAME
-    name: str = _BACKEND_NAME
+    adapter: str = _ADAPTER_NAME
+    name: str = _ADAPTER_NAME
     capacity: int = _DEFAULT_CAPACITY
     history_limit: int = _DEFAULT_HISTORY_LIMIT
     max_brokers: int = _DEFAULT_MAX_BROKERS
     topics: list[str] = field(default_factory=list)
 
     def validate(self) -> None:
-        """Validate in-memory backend settings."""
+        """Validate in-memory adapter settings."""
         super().validate()
-        reject_exactly_once(self, _BACKEND_NAME)
+        reject_exactly_once(self, _ADAPTER_NAME)
         if self.capacity < 1:
             raise AppError.invalid_input("capacity", "capacity must be at least 1")
         if self.history_limit < 1:
@@ -138,8 +138,8 @@ def register(registry: MessagingRegistry) -> None:
             config.validate()
         else:
             config.validate()
-            reject_exactly_once(config, _BACKEND_NAME)
-        key = config.name or config.backend
+            reject_exactly_once(config, _ADAPTER_NAME)
+        key = config.name or config.adapter
         broker = brokers.get(key)
         if broker is not None:
             brokers.move_to_end(key)
@@ -166,14 +166,14 @@ def register(registry: MessagingRegistry) -> None:
             getattr(config, "subscriptions", []) or getattr(config, "topics", [])
         )
 
-    registry.register_producer(_BACKEND_NAME, producer)
-    registry.register_consumer(_BACKEND_NAME, consumer)
-    registry.register_backend_state_cleanup(_BACKEND_NAME, brokers.clear)
+    registry.register_producer(_ADAPTER_NAME, producer)
+    registry.register_consumer(_ADAPTER_NAME, consumer)
+    registry.register_adapter_state_cleanup(_ADAPTER_NAME, brokers.clear)
 
 
 def clear_memory_brokers(registry: MessagingRegistry) -> None:
     """Clear in-memory broker instances owned by *registry*."""
-    registry.clear_backend_state(_BACKEND_NAME)
+    registry.clear_adapter_state(_ADAPTER_NAME)
 
 
 class InMemoryProducer:

--- a/packages/pykit-messaging/src/pykit_messaging/memory.py
+++ b/packages/pykit-messaging/src/pykit_messaging/memory.py
@@ -4,24 +4,70 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from collections import defaultdict
+from collections import OrderedDict, defaultdict, deque
+from collections.abc import MutableMapping
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
-from pykit_messaging.types import Event, Message, MessageHandler
+from pykit_errors import AppError
+from pykit_messaging.config import BrokerConfig, DeliveryGuarantee, reject_exactly_once
+from pykit_messaging.types import Event, JsonValue, Message, MessageHandler
 from pykit_util import JsonCodec
+
+if TYPE_CHECKING:
+    from pykit_messaging.registry import MessagingRegistry
+
+_BACKEND_NAME = "memory"
+_DEFAULT_CAPACITY = 256
+_DEFAULT_HISTORY_LIMIT = 1024
+_DEFAULT_MAX_BROKERS = 32
+
+
+@dataclass
+class MemoryConfig(BrokerConfig):
+    """Configuration for the in-memory messaging backend."""
+
+    backend: str = _BACKEND_NAME
+    name: str = _BACKEND_NAME
+    capacity: int = _DEFAULT_CAPACITY
+    history_limit: int = _DEFAULT_HISTORY_LIMIT
+    max_brokers: int = _DEFAULT_MAX_BROKERS
+    topics: list[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        """Validate in-memory backend settings."""
+        super().validate()
+        reject_exactly_once(self, _BACKEND_NAME)
+        if self.capacity < 1:
+            raise AppError.invalid_input("capacity", "capacity must be at least 1")
+        if self.history_limit < 1:
+            raise AppError.invalid_input("history_limit", "history_limit must be at least 1")
+        if self.max_brokers < 1:
+            raise AppError.invalid_input("max_brokers", "max_brokers must be at least 1")
+        if self.delivery_guarantee is DeliveryGuarantee.AT_MOST_ONCE and self.max_in_flight != 1:
+            raise AppError.invalid_input(
+                "max_in_flight", "in-memory at-most-once delivery supports max_in_flight=1 only"
+            )
 
 
 class InMemoryBroker:
     """Channel-based message broker for testing.
 
-    Every message published through the broker is recorded in an internal
-    history list so that test assertion helpers can inspect what was sent.
+    Published messages are recorded in a bounded internal history so that test
+    assertion helpers can inspect recent messages without unbounded growth.
     """
 
-    def __init__(self, capacity: int = 256) -> None:
+    def __init__(
+        self, capacity: int = _DEFAULT_CAPACITY, history_limit: int = _DEFAULT_HISTORY_LIMIT
+    ) -> None:
+        if capacity < 1:
+            raise ValueError("capacity must be at least 1")
+        if history_limit < 1:
+            raise ValueError("history_limit must be at least 1")
         self._queues: dict[str, asyncio.Queue[Message]] = defaultdict(lambda: asyncio.Queue(maxsize=capacity))
         self._capacity = capacity
-        self._history: list[Message] = []
+        self._history: deque[Message] = deque(maxlen=history_limit)
         self._topics: set[str] = set()
         self._lock = threading.Lock()
         self._event = asyncio.Event()
@@ -83,12 +129,59 @@ class InMemoryBroker:
         self._event.clear()
 
 
+def register(registry: MessagingRegistry) -> None:
+    """Register config-free in-memory producer and consumer factories."""
+    brokers: OrderedDict[str, InMemoryBroker] = OrderedDict()
+
+    def broker_for(config: BrokerConfig) -> InMemoryBroker:
+        if isinstance(config, MemoryConfig):
+            config.validate()
+        else:
+            config.validate()
+            reject_exactly_once(config, _BACKEND_NAME)
+        key = config.name or config.backend
+        broker = brokers.get(key)
+        if broker is not None:
+            brokers.move_to_end(key)
+            return broker
+
+        max_brokers = getattr(config, "max_brokers", _DEFAULT_MAX_BROKERS)
+        if max_brokers < 1:
+            raise AppError.invalid_input("max_brokers", "max_brokers must be at least 1")
+        while len(brokers) >= max_brokers:
+            brokers.popitem(last=False)
+
+        broker = InMemoryBroker(
+            capacity=getattr(config, "capacity", _DEFAULT_CAPACITY),
+            history_limit=getattr(config, "history_limit", _DEFAULT_HISTORY_LIMIT),
+        )
+        brokers[key] = broker
+        return broker
+
+    def producer(config: BrokerConfig) -> InMemoryProducer:
+        return broker_for(config).producer()
+
+    def consumer(config: BrokerConfig) -> InMemoryConsumer:
+        return broker_for(config).consumer(
+            getattr(config, "subscriptions", []) or getattr(config, "topics", [])
+        )
+
+    registry.register_producer(_BACKEND_NAME, producer)
+    registry.register_consumer(_BACKEND_NAME, consumer)
+    registry.register_backend_state_cleanup(_BACKEND_NAME, brokers.clear)
+
+
+def clear_memory_brokers(registry: MessagingRegistry) -> None:
+    """Clear in-memory broker instances owned by *registry*."""
+    registry.clear_backend_state(_BACKEND_NAME)
+
+
 class InMemoryProducer:
     """Implements MessageProducer protocol using in-memory queues."""
 
     def __init__(
         self,
-        queues: dict[str, asyncio.Queue[Message]],
+        queues: MutableMapping[str, asyncio.Queue[Message]],
         broker: InMemoryBroker,
     ) -> None:
         self._queues = queues
@@ -118,9 +211,9 @@ class InMemoryProducer:
         """Send a structured event to *topic*."""
         await self.send(topic, event.to_json(), key=event.subject or None)
 
-    async def send_json(self, topic: str, data: object, key: str | None = None) -> None:
+    async def send_json(self, topic: str, data: JsonValue, key: str | None = None) -> None:
         """Send a JSON-serialised payload to *topic*."""
-        value = JsonCodec[object]().encode(data)
+        value = JsonCodec[JsonValue]().encode(data)
         await self.send(topic, value, key=key)
 
     async def send_batch(self, messages: list[Message]) -> None:

--- a/packages/pykit-messaging/src/pykit_messaging/middleware/__init__.py
+++ b/packages/pykit-messaging/src/pykit_messaging/middleware/__init__.py
@@ -7,7 +7,7 @@ from pykit_messaging.middleware.circuit_breaker import (
     CircuitBreakerHandler,
     circuit_breaker,
 )
-from pykit_messaging.middleware.dead_letter import DeadLetterConfig, DeadLetterProducer
+from pykit_messaging.middleware.dead_letter import DeadLetterConfig, DeadLetterEnvelope, DeadLetterProducer
 from pykit_messaging.middleware.dedup import DedupConfig, DedupHandler, dedup
 from pykit_messaging.middleware.metrics import MetricsHandler, instrument
 from pykit_messaging.middleware.retry import RetryConfig, RetryHandler, retry
@@ -17,6 +17,7 @@ __all__ = [
     "CircuitBreakerConfig",
     "CircuitBreakerHandler",
     "DeadLetterConfig",
+    "DeadLetterEnvelope",
     "DeadLetterProducer",
     "DedupConfig",
     "DedupHandler",

--- a/packages/pykit-messaging/src/pykit_messaging/middleware/circuit_breaker.py
+++ b/packages/pykit-messaging/src/pykit_messaging/middleware/circuit_breaker.py
@@ -2,62 +2,46 @@
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from enum import StrEnum
 
 from pykit_messaging.handler import MessageHandlerProtocol
 from pykit_messaging.types import Message
-
-logger = logging.getLogger(__name__)
-
-
-class CircuitState(StrEnum):
-    """Circuit breaker states."""
-
-    CLOSED = "closed"
-    OPEN = "open"
-    HALF_OPEN = "half-open"
-
-
-class CircuitOpenError(Exception):
-    """Raised when the circuit breaker is open and the message is rejected."""
-
-    def __init__(self) -> None:
-        super().__init__("Circuit breaker is open")
+from pykit_resilience import (
+    CircuitBreaker,
+    CircuitOpenError,
+)
+from pykit_resilience import (
+    CircuitBreakerConfig as ResilienceCircuitBreakerConfig,
+)
+from pykit_resilience import (
+    State as CircuitState,
+)
 
 
 @dataclass(frozen=True)
 class CircuitBreakerConfig:
-    """Configuration for the circuit breaker middleware.
-
-    Args:
-        threshold: Consecutive failures required to trip the circuit open.
-        timeout: Seconds to wait before transitioning from open to half-open.
-        half_open_max: Maximum probe requests allowed in the half-open state.
-    """
+    """Configuration for the circuit breaker middleware."""
 
     threshold: int = 5
     timeout: float = 30.0
     half_open_max: int = 2
+    name: str = "messaging-handler"
+    on_state_change: Callable[[str, CircuitState, CircuitState], None] | None = None
+
+    def to_resilience_config(self) -> ResilienceCircuitBreakerConfig:
+        """Convert to the canonical resilience circuit breaker config."""
+        return ResilienceCircuitBreakerConfig(
+            name=self.name,
+            max_failures=self.threshold,
+            timeout=self.timeout,
+            half_open_max_calls=self.half_open_max,
+            on_state_change=self.on_state_change,
+        )
 
 
 class CircuitBreakerHandler:
-    """Fails fast when the downstream handler is unhealthy.
-
-    Implements the classic circuit breaker pattern with three states:
-      - **CLOSED**: Normal operation, requests pass through.
-      - **OPEN**: Downstream unhealthy, requests are rejected immediately.
-      - **HALF_OPEN**: Recovery probe, limited requests allowed.
-
-    Args:
-        inner: The handler to delegate to when the circuit is not open.
-        config: Optional circuit breaker configuration; defaults to
-            ``CircuitBreakerConfig()``.
-    """
+    """Fails fast when the downstream handler is unhealthy."""
 
     def __init__(
         self,
@@ -66,110 +50,42 @@ class CircuitBreakerHandler:
     ) -> None:
         self._inner = inner
         self._config = config or CircuitBreakerConfig()
-        self._state = CircuitState.CLOSED
-        self._failures = 0
-        self._successes = 0
-        self._half_open_calls = 0
-        self._last_failure_time: float = 0.0
-        self._lock = asyncio.Lock()
+        self._breaker = CircuitBreaker(self._config.to_resilience_config())
 
     @property
     def state(self) -> CircuitState:
         """Current circuit breaker state."""
-        self._check_timeout()
-        return self._state
+        return self._breaker.state
+
+    @property
+    def failures(self) -> int:
+        """Current failure count."""
+        return self._breaker.failures
 
     async def handle(self, msg: Message) -> None:
-        """Handle a message through the circuit breaker.
+        """Handle a message through the canonical circuit breaker."""
 
-        Args:
-            msg: The message to handle.
-
-        Raises:
-            CircuitOpenError: If the circuit is open or half-open limit reached.
-        """
-        async with self._lock:
-            if not self._allow_request():
-                raise CircuitOpenError
-        try:
+        async def _handle() -> None:
             await self._inner.handle(msg)
-        except Exception:
-            async with self._lock:
-                self._on_failure()
-            raise
-        else:
-            async with self._lock:
-                self._on_success()
 
-    def _allow_request(self) -> bool:
-        """Determine whether a request should be allowed through."""
-        self._check_timeout()
-        if self._state == CircuitState.CLOSED:
-            return True
-        if self._state == CircuitState.OPEN:
-            return False
-        # HALF_OPEN
-        if self._half_open_calls < self._config.half_open_max:
-            self._half_open_calls += 1
-            return True
-        return False
-
-    def _on_success(self) -> None:
-        """Record a successful call."""
-        self._check_timeout()
-        if self._state == CircuitState.CLOSED:
-            self._failures = 0
-        elif self._state == CircuitState.HALF_OPEN:
-            self._successes += 1
-            if self._successes >= self._config.half_open_max:
-                self._to_state(CircuitState.CLOSED)
-
-    def _on_failure(self) -> None:
-        """Record a failed call."""
-        self._failures += 1
-        self._last_failure_time = time.monotonic()
-        self._check_timeout()
-        if self._state == CircuitState.CLOSED:
-            if self._failures >= self._config.threshold:
-                self._to_state(CircuitState.OPEN)
-        elif self._state == CircuitState.HALF_OPEN:
-            self._to_state(CircuitState.OPEN)
-
-    def _check_timeout(self) -> None:
-        """Transition from OPEN to HALF_OPEN if timeout has elapsed."""
-        if (
-            self._state == CircuitState.OPEN
-            and self._last_failure_time > 0
-            and (time.monotonic() - self._last_failure_time) >= self._config.timeout
-        ):
-            self._to_state(CircuitState.HALF_OPEN)
-
-    def _to_state(self, to: CircuitState) -> None:
-        """Transition to a new state."""
-        if self._state == to:
-            return
-        old = self._state
-        self._state = to
-        self._half_open_calls = 0
-        self._successes = 0
-        if to == CircuitState.CLOSED:
-            self._failures = 0
-        logger.info("Circuit breaker: %s -> %s", old, to)
+        await self._breaker.execute(_handle)
 
 
 def circuit_breaker(
     config: CircuitBreakerConfig | None = None,
 ) -> Callable[[MessageHandlerProtocol], MessageHandlerProtocol]:
-    """Return a middleware function implementing the circuit breaker pattern.
-
-    Args:
-        config: Optional circuit breaker configuration.
-
-    Returns:
-        A middleware function compatible with ``chain_handlers``.
-    """
+    """Return a middleware function implementing canonical circuit breaking."""
 
     def _middleware(inner: MessageHandlerProtocol) -> MessageHandlerProtocol:
         return CircuitBreakerHandler(inner, config)
 
     return _middleware
+
+
+__all__ = [
+    "CircuitBreakerConfig",
+    "CircuitBreakerHandler",
+    "CircuitOpenError",
+    "CircuitState",
+    "circuit_breaker",
+]

--- a/packages/pykit-messaging/src/pykit_messaging/middleware/dead_letter.py
+++ b/packages/pykit-messaging/src/pykit_messaging/middleware/dead_letter.py
@@ -2,34 +2,48 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
 from pykit_messaging.protocols import MessageProducer
 from pykit_messaging.types import Message
+from pykit_util import JsonCodec
+
+_SENSITIVE_HEADER_PARTS = (
+    "authorization",
+    "cookie",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "api-key",
+    "apikey",
+)
+_MAX_DLQ_PAYLOAD_CHARS = 4096
+_REDACTED = "<redacted>"
 
 
 @dataclass(frozen=True)
 class DeadLetterConfig:
-    """Configuration for dead-letter routing.
-
-    Args:
-        suffix: Suffix to append to topic name for the dead-letter queue.
-    """
+    """Configuration for dead-letter routing."""
 
     suffix: str = ".dlq"
 
 
+@dataclass
+class DeadLetterEnvelope:
+    """Envelope written to the DLQ topic."""
+
+    original_topic: str
+    error: str
+    retry_count: int
+    timestamp: str
+    headers: dict[str, str] = field(default_factory=dict)
+    payload: str = ""
+
+
 class DeadLetterProducer:
-    """Routes failed messages to a dead-letter topic.
-
-    The DLQ topic is derived from the original message topic by appending
-    the configured suffix (default: ``.dlq``). Error details are stored
-    in message headers.
-
-    Args:
-        producer: The message producer to send DLQ messages with.
-        config: Optional dead-letter configuration; defaults to ``DeadLetterConfig()``.
-    """
+    """Routes terminally failed messages to a dead-letter topic."""
 
     def __init__(
         self,
@@ -40,23 +54,64 @@ class DeadLetterProducer:
         self._config = config or DeadLetterConfig()
 
     async def send(self, msg: Message, error: Exception) -> None:
-        """Send a failed message to the dead-letter queue.
+        """Send a failed message envelope to the dead-letter queue."""
+        retry_count = 0
+        rc = msg.headers.get("x-retry-count", "")
+        if rc.isdigit():
+            retry_count = int(rc)
 
-        The error message is added to headers under ``x-dlq-error``, and the
-        original topic is recorded under ``x-dlq-original-topic``.
-
-        Args:
-            msg: The message that failed processing.
-            error: The exception that caused the failure.
-        """
-        dlq_topic = msg.topic + self._config.suffix
-        headers = dict(msg.headers) if msg.headers else {}
-        headers["x-dlq-error"] = str(error)
-        headers["x-dlq-original-topic"] = msg.topic
+        envelope = DeadLetterEnvelope(
+            original_topic=msg.topic,
+            error=_sanitize_summary(str(error)),
+            retry_count=retry_count,
+            timestamp=datetime.now(UTC).isoformat(),
+            headers=_redact_headers(msg.headers),
+            payload=_payload_summary(msg.value),
+        )
+        payload = JsonCodec[dict[str, object]]().encode(
+            {
+                "original_topic": envelope.original_topic,
+                "error": envelope.error,
+                "retry_count": envelope.retry_count,
+                "timestamp": envelope.timestamp,
+                "headers": envelope.headers,
+                "payload": envelope.payload,
+            }
+        )
 
         await self._producer.send(
-            topic=dlq_topic,
-            value=msg.value,
-            key=msg.key,
-            headers=headers,
+            msg.topic + self._config.suffix,
+            value=payload,
+            key=msg.key or "dlq",
         )
+
+
+def _redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {
+        key: (_REDACTED if _is_sensitive(key) or _is_sensitive(value) else value)
+        for key, value in headers.items()
+    }
+
+
+def _sanitize_summary(value: str) -> str:
+    if _is_sensitive(value):
+        return _REDACTED
+    return _truncate(value)
+
+
+def _payload_summary(value: bytes) -> str:
+    text = value.decode(errors="replace")
+    if _is_sensitive(text):
+        return _REDACTED
+    return _truncate(text)
+
+
+def _truncate(value: str) -> str:
+    if len(value) <= _MAX_DLQ_PAYLOAD_CHARS:
+        return value
+    return value[:_MAX_DLQ_PAYLOAD_CHARS] + "…"
+
+
+def _is_sensitive(value: str) -> bool:
+    lowered = value.lower()
+    return any(part in lowered for part in _SENSITIVE_HEADER_PARTS)

--- a/packages/pykit-messaging/src/pykit_messaging/middleware/retry.py
+++ b/packages/pykit-messaging/src/pykit_messaging/middleware/retry.py
@@ -40,9 +40,11 @@ class RetryHandler:
         try:
             await retry_async(_handle, cfg)
         except RetryExhaustedError as exc:
-            if cfg.on_exhausted is None:
-                raise exc.last_error from exc
-            await cfg.on_exhausted(msg, exc.last_error)
+            if cfg.on_exhausted is not None:
+                await cfg.on_exhausted(msg, exc.last_error)
+            # Always re-raise terminal error so outer middleware (circuit breaker, metrics)
+            # knows this was a failure, even if on_exhausted() succeeds (e.g., DLQ handling).
+            raise exc.last_error from exc
 
 
 def retry(

--- a/packages/pykit-messaging/src/pykit_messaging/middleware/retry.py
+++ b/packages/pykit-messaging/src/pykit_messaging/middleware/retry.py
@@ -2,46 +2,25 @@
 
 from __future__ import annotations
 
-import asyncio
-import random
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from pykit_messaging.handler import MessageHandlerProtocol
 from pykit_messaging.types import Message
+from pykit_resilience import RetryConfig as ResilienceRetryConfig
+from pykit_resilience import RetryExhaustedError
+from pykit_resilience import retry as retry_async
 
 
-@dataclass(frozen=True)
-class RetryConfig:
-    """Configuration for retry middleware.
+@dataclass
+class RetryConfig(ResilienceRetryConfig):
+    """Configuration for retry middleware."""
 
-    Args:
-        max_attempts: Maximum number of retry attempts (including initial attempt).
-        initial_backoff: Initial backoff duration in seconds.
-        max_backoff: Maximum backoff duration in seconds.
-        backoff_factor: Exponential backoff multiplier per attempt.
-        jitter: Jitter range as fraction of backoff (0.1 = ±10%).
-        on_exhausted: Optional callback when all retries are exhausted.
-    """
-
-    max_attempts: int = 3
-    initial_backoff: float = 0.1
-    max_backoff: float = 10.0
-    backoff_factor: float = 2.0
-    jitter: float = 0.1
     on_exhausted: Callable[[Message, Exception], Awaitable[None]] | None = None
 
 
 class RetryHandler:
-    """Retries failed message handling with exponential backoff.
-
-    After all attempts are exhausted, calls ``on_exhausted`` (if set)
-    and re-raises the last exception.
-
-    Args:
-        inner: The handler to delegate to.
-        config: Optional retry configuration; defaults to ``RetryConfig()``.
-    """
+    """Retries failed message handling using pykit-resilience."""
 
     def __init__(
         self,
@@ -52,46 +31,24 @@ class RetryHandler:
         self._config = config or RetryConfig()
 
     async def handle(self, msg: Message) -> None:
-        """Handle a message with retry logic.
-
-        Args:
-            msg: The message to handle.
-
-        Raises:
-            The last exception encountered if all retries are exhausted.
-        """
+        """Handle a message with retry logic."""
         cfg = self._config
-        last_err: Exception | None = None
-        backoff = cfg.initial_backoff
 
-        for attempt in range(cfg.max_attempts):
-            try:
-                await self._inner.handle(msg)
-                return
-            except Exception as exc:
-                last_err = exc
-                if attempt < cfg.max_attempts - 1:
-                    jittered = backoff * (1 + random.uniform(-cfg.jitter, cfg.jitter))
-                    await asyncio.sleep(jittered)
-                    backoff = min(backoff * cfg.backoff_factor, cfg.max_backoff)
+        async def _handle() -> None:
+            await self._inner.handle(msg)
 
-        if last_err is not None:
-            if cfg.on_exhausted is not None:
-                await cfg.on_exhausted(msg, last_err)
-            raise last_err
+        try:
+            await retry_async(_handle, cfg)
+        except RetryExhaustedError as exc:
+            if cfg.on_exhausted is None:
+                raise exc.last_error from exc
+            await cfg.on_exhausted(msg, exc.last_error)
 
 
 def retry(
     config: RetryConfig | None = None,
 ) -> Callable[[MessageHandlerProtocol], MessageHandlerProtocol]:
-    """Return a middleware function implementing exponential backoff retry logic.
-
-    Args:
-        config: Optional retry configuration.
-
-    Returns:
-        A middleware function compatible with ``chain_handlers``.
-    """
+    """Return a middleware function implementing canonical retry behavior."""
 
     def _middleware(handler: MessageHandlerProtocol) -> MessageHandlerProtocol:
         return RetryHandler(handler, config)

--- a/packages/pykit-messaging/src/pykit_messaging/nats/__init__.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/__init__.py
@@ -1,0 +1,31 @@
+"""NATS provider for pykit-messaging."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import TYPE_CHECKING
+
+from pykit_messaging.config import BrokerConfig
+from pykit_messaging.nats.config import BACKEND_NAME, NatsConfig
+from pykit_messaging.nats.consumer import NatsConsumer
+from pykit_messaging.nats.producer import NatsProducer
+
+if TYPE_CHECKING:
+    from pykit_messaging.registry import MessagingRegistry
+
+
+def register(registry: MessagingRegistry) -> None:
+    """Register config-free NATS producer and consumer factories."""
+    registry.register_producer(BACKEND_NAME, lambda config: NatsProducer(_config_from(config)))
+    registry.register_consumer(BACKEND_NAME, lambda config: NatsConsumer(_config_from(config)))
+
+
+def _config_from(config: BrokerConfig) -> NatsConfig:
+    if isinstance(config, NatsConfig):
+        config.validate()
+        return config
+    allowed = {field.name for field in fields(NatsConfig)}
+    return NatsConfig(**{key: value for key, value in config.__dict__.items() if key in allowed})
+
+
+__all__ = ["NatsConfig", "NatsConsumer", "NatsProducer", "register"]

--- a/packages/pykit-messaging/src/pykit_messaging/nats/__init__.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/__init__.py
@@ -6,7 +6,7 @@ from dataclasses import fields
 from typing import TYPE_CHECKING
 
 from pykit_messaging.config import BrokerConfig
-from pykit_messaging.nats.config import BACKEND_NAME, NatsConfig
+from pykit_messaging.nats.config import ADAPTER_NAME, NatsConfig
 from pykit_messaging.nats.consumer import NatsConsumer
 from pykit_messaging.nats.producer import NatsProducer
 
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 
 def register(registry: MessagingRegistry) -> None:
     """Register config-free NATS producer and consumer factories."""
-    registry.register_producer(BACKEND_NAME, lambda config: NatsProducer(_config_from(config)))
-    registry.register_consumer(BACKEND_NAME, lambda config: NatsConsumer(_config_from(config)))
+    registry.register_producer(ADAPTER_NAME, lambda config: NatsProducer(_config_from(config)))
+    registry.register_consumer(ADAPTER_NAME, lambda config: NatsConsumer(_config_from(config)))
 
 
 def _config_from(config: BrokerConfig) -> NatsConfig:

--- a/packages/pykit-messaging/src/pykit_messaging/nats/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/config.py
@@ -14,7 +14,7 @@ from pykit_messaging.config import (
     validate_topic_name,
 )
 
-BACKEND_NAME = "nats"
+ADAPTER_NAME = "nats"
 DEFAULT_URL = "tls://localhost:4222"
 
 
@@ -22,8 +22,8 @@ DEFAULT_URL = "tls://localhost:4222"
 class NatsConfig(BrokerConfig):
     """Configuration for the core NATS adapter."""
 
-    backend: str = BACKEND_NAME
-    name: str = BACKEND_NAME
+    adapter: str = ADAPTER_NAME
+    name: str = ADAPTER_NAME
     delivery_guarantee: DeliveryGuarantee = DeliveryGuarantee.AT_MOST_ONCE
     commit_strategy: CommitStrategy = CommitStrategy.AUTO
 
@@ -43,7 +43,7 @@ class NatsConfig(BrokerConfig):
     def validate(self) -> None:
         """Validate NATS-specific and broker-neutral settings."""
         super().validate()
-        reject_exactly_once(self, BACKEND_NAME)
+        reject_exactly_once(self, ADAPTER_NAME)
         if self.delivery_guarantee is not DeliveryGuarantee.AT_MOST_ONCE:
             raise AppError.invalid_input(
                 "delivery_guarantee", "core NATS subjects support at-most-once delivery only"

--- a/packages/pykit-messaging/src/pykit_messaging/nats/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/config.py
@@ -1,0 +1,97 @@
+"""NATS adapter configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+from pykit_errors import AppError
+from pykit_messaging.config import (
+    BrokerConfig,
+    CommitStrategy,
+    DeliveryGuarantee,
+    reject_exactly_once,
+    validate_topic_name,
+)
+
+BACKEND_NAME = "nats"
+DEFAULT_URL = "tls://localhost:4222"
+
+
+@dataclass
+class NatsConfig(BrokerConfig):
+    """Configuration for the core NATS adapter."""
+
+    backend: str = BACKEND_NAME
+    name: str = BACKEND_NAME
+    delivery_guarantee: DeliveryGuarantee = DeliveryGuarantee.AT_MOST_ONCE
+    commit_strategy: CommitStrategy = CommitStrategy.AUTO
+
+    url: str = field(default=DEFAULT_URL, repr=False)
+    brokers: list[str] = field(default_factory=list, repr=False)
+    subject_prefix: str = ""
+    queue_group: str = ""
+    connect_timeout: float = 2.0
+    drain_timeout: float = 2.0
+    reconnect_time_wait: float = 2.0
+    allow_reconnect: bool = True
+    token: str = field(default="", repr=False)
+    username: str = field(default="", repr=False)
+    password: str = field(default="", repr=False)
+    allow_insecure_dev: bool = False
+
+    def validate(self) -> None:
+        """Validate NATS-specific and broker-neutral settings."""
+        super().validate()
+        reject_exactly_once(self, BACKEND_NAME)
+        if self.delivery_guarantee is not DeliveryGuarantee.AT_MOST_ONCE:
+            raise AppError.invalid_input(
+                "delivery_guarantee", "core NATS subjects support at-most-once delivery only"
+            )
+        if self.commit_strategy is not CommitStrategy.AUTO:
+            raise AppError.invalid_input("commit_strategy", "core NATS subjects do not support manual acks")
+        if not self.servers():
+            raise AppError.invalid_input("brokers", "at least one NATS server URL is required")
+        for server in self.servers():
+            _validate_server_url(server, self.allow_insecure_dev)
+        if self.subject_prefix:
+            validate_topic_name(self.subject_prefix.strip("."), "subject_prefix")
+        if self.queue_group:
+            validate_topic_name(self.queue_group, "queue_group")
+        if self.connect_timeout <= 0:
+            raise AppError.invalid_input("connect_timeout", "connect_timeout must be greater than 0")
+        if self.drain_timeout < 0:
+            raise AppError.invalid_input("drain_timeout", "drain_timeout must be greater than or equal to 0")
+        if self.reconnect_time_wait < 0:
+            raise AppError.invalid_input(
+                "reconnect_time_wait", "reconnect_time_wait must be greater than or equal to 0"
+            )
+        if self.token and (self.username or self.password):
+            raise AppError.invalid_input("auth", "NATS token auth cannot be combined with username/password")
+        if bool(self.username) != bool(self.password):
+            raise AppError.invalid_input("auth", "NATS username and password must be provided together")
+
+    def servers(self) -> list[str]:
+        """Return configured NATS server URLs."""
+        return [server for server in (self.brokers or [self.url]) if server]
+
+    def subject(self, topic: str) -> str:
+        """Return topic with the configured subject prefix applied."""
+        validate_topic_name(topic, "topic")
+        if not self.subject_prefix:
+            return topic
+        return f"{self.subject_prefix.rstrip('.')}.{topic.lstrip('.')}"
+
+
+def _validate_server_url(value: str, allow_insecure_dev: bool) -> None:
+    parsed = urlparse(value)
+    if not parsed.scheme or not parsed.hostname:
+        raise AppError.invalid_input("brokers", "NATS server URL must include a scheme and host")
+    if parsed.username or parsed.password:
+        raise AppError.invalid_input(
+            "brokers", "NATS credentials must be configured via token or username/password, not URL userinfo"
+        )
+    if parsed.query:
+        raise AppError.invalid_input("brokers", "NATS server URL query strings are not accepted")
+    if parsed.scheme not in {"tls", "wss"} and not allow_insecure_dev:
+        raise AppError.invalid_input("brokers", "NATS plaintext URLs require allow_insecure_dev=True")

--- a/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
@@ -70,6 +70,7 @@ class NatsConsumer:
         client = _require_client(self._client)
 
         for topic in self._topics:
+
             async def _make_callback(
                 logical_topic: str,
             ) -> object:

--- a/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Mapping
 from datetime import UTC, datetime
 from inspect import isawaitable
 from typing import Protocol, cast
@@ -23,6 +23,10 @@ class _NatsClient(Protocol):
     def close(self) -> Awaitable[None] | None: ...
 
     async def subscribe(self, subject: str, *, cb: object, queue: str = "") -> object: ...
+
+
+class _NatsModule(Protocol):
+    def connect(self, **kwargs: object) -> Awaitable[_NatsClient]: ...
 
 
 class NatsConsumer:
@@ -53,7 +57,7 @@ class NatsConsumer:
         if self._config.username:
             kwargs["user"] = self._config.username
             kwargs["password"] = self._config.password
-        self._client = cast("_NatsClient", await nats.connect(**kwargs))
+        self._client = await nats.connect(**kwargs)
         self._closed.clear()
 
     async def subscribe(self, topics: list[str]) -> None:
@@ -94,9 +98,9 @@ class NatsConsumer:
         self._client = None
 
 
-def _import_nats() -> object:
+def _import_nats() -> _NatsModule:
     try:
-        return importlib.import_module("nats")
+        return cast("_NatsModule", importlib.import_module("nats"))
     except ImportError as exc:
         msg = "nats-py is required for NATS messaging; install pykit-messaging[nats]"
         raise ImportError(msg) from exc
@@ -126,9 +130,11 @@ def _to_message(raw_message: object) -> Message:
 def _headers_to_dict(raw_headers: object) -> dict[str, str]:
     if raw_headers is None:
         return {}
-    items = cast("object", raw_headers).items()
+    if not isinstance(raw_headers, Mapping):
+        return {}
+    headers_map = cast("Mapping[object, object]", raw_headers)
     headers: dict[str, str] = {}
-    for key, value in items:
+    for key, value in headers_map.items():
         if isinstance(value, list):
             headers[str(key)] = str(value[-1]) if value else ""
         else:

--- a/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
@@ -1,0 +1,136 @@
+"""NATS consumer adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from collections.abc import Awaitable
+from datetime import UTC, datetime
+from inspect import isawaitable
+from typing import Protocol, cast
+
+from pykit_messaging.nats.config import NatsConfig
+from pykit_messaging.types import Message, MessageHandler
+
+
+class _NatsRawMessage(Protocol):
+    subject: str
+    data: bytes
+    headers: object | None
+
+
+class _NatsClient(Protocol):
+    def close(self) -> Awaitable[None] | None: ...
+
+    async def subscribe(self, subject: str, *, cb: object, queue: str = "") -> object: ...
+
+
+class NatsConsumer:
+    """NATS-backed message consumer requiring the ``nats`` extra."""
+
+    def __init__(self, config: NatsConfig) -> None:
+        config.validate()
+        self._config = config
+        self._topics = list(config.topics)
+        self._client: _NatsClient | None = None
+        self._subscriptions: list[object] = []
+        self._closed = asyncio.Event()
+
+    async def start(self) -> None:
+        """Connect to NATS."""
+        if self._client is not None:
+            return
+        nats = _import_nats()
+        kwargs: dict[str, object] = {
+            "servers": self._config.servers(),
+            "connect_timeout": self._config.connect_timeout,
+            "max_reconnect_attempts": self._config.retries,
+            "reconnect_time_wait": self._config.reconnect_time_wait,
+            "allow_reconnect": self._config.allow_reconnect,
+        }
+        if self._config.token:
+            kwargs["token"] = self._config.token
+        if self._config.username:
+            kwargs["user"] = self._config.username
+            kwargs["password"] = self._config.password
+        self._client = cast("_NatsClient", await nats.connect(**kwargs))
+        self._closed.clear()
+
+    async def subscribe(self, topics: list[str]) -> None:
+        """Set NATS subjects consumed by this consumer."""
+        self._topics = list(topics)
+
+    async def consume(self, handler: MessageHandler) -> None:
+        """Subscribe to configured subjects and dispatch messages until closed."""
+        await self.start()
+        client = _require_client(self._client)
+
+        async def _callback(raw_message: object) -> None:
+            await handler(_to_message(raw_message))
+
+        for topic in self._topics:
+            self._subscriptions.append(
+                await client.subscribe(
+                    self._config.subject(topic), cb=_callback, queue=self._config.queue_group
+                )
+            )
+        await self._closed.wait()
+
+    async def close(self) -> None:
+        """Stop consuming and close the NATS connection."""
+        self._closed.set()
+        for subscription in self._subscriptions:
+            unsubscribe = getattr(subscription, "unsubscribe", None)
+            if unsubscribe is not None:
+                result = unsubscribe()
+                if isawaitable(result):
+                    await result
+        self._subscriptions.clear()
+        if self._client is None:
+            return
+        result = self._client.close()
+        if isawaitable(result):
+            await result
+        self._client = None
+
+
+def _import_nats() -> object:
+    try:
+        return importlib.import_module("nats")
+    except ImportError as exc:
+        msg = "nats-py is required for NATS messaging; install pykit-messaging[nats]"
+        raise ImportError(msg) from exc
+
+
+def _require_client(client: _NatsClient | None) -> _NatsClient:
+    if client is None:
+        raise RuntimeError("NATS client is not started")
+    return client
+
+
+def _to_message(raw_message: object) -> Message:
+    message = cast("_NatsRawMessage", raw_message)
+    headers = _headers_to_dict(message.headers)
+    key = headers.pop("message-key", None)
+    return Message(
+        key=key,
+        value=message.data,
+        topic=message.subject,
+        partition=0,
+        offset=0,
+        timestamp=datetime.now(UTC),
+        headers=headers,
+    )
+
+
+def _headers_to_dict(raw_headers: object) -> dict[str, str]:
+    if raw_headers is None:
+        return {}
+    items = cast("object", raw_headers).items()
+    headers: dict[str, str] = {}
+    for key, value in items:
+        if isinstance(value, list):
+            headers[str(key)] = str(value[-1]) if value else ""
+        else:
+            headers[str(key)] = str(value)
+    return headers

--- a/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
@@ -35,7 +35,7 @@ class NatsConsumer:
     def __init__(self, config: NatsConfig) -> None:
         config.validate()
         self._config = config
-        self._topics = list(config.topics)
+        self._topics = list(config.topics or config.subscriptions)
         self._client: _NatsClient | None = None
         self._subscriptions: list[object] = []
         self._closed = asyncio.Event()

--- a/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/consumer.py
@@ -69,13 +69,20 @@ class NatsConsumer:
         await self.start()
         client = _require_client(self._client)
 
-        async def _callback(raw_message: object) -> None:
-            await handler(_to_message(raw_message))
-
         for topic in self._topics:
+            async def _make_callback(
+                logical_topic: str,
+            ) -> object:
+                async def _callback(raw_message: object) -> None:
+                    await handler(_to_message(raw_message, logical_topic))
+
+                return _callback
+
             self._subscriptions.append(
                 await client.subscribe(
-                    self._config.subject(topic), cb=_callback, queue=self._config.queue_group
+                    self._config.subject(topic),
+                    cb=await _make_callback(topic),
+                    queue=self._config.queue_group,
                 )
             )
         await self._closed.wait()
@@ -112,14 +119,17 @@ def _require_client(client: _NatsClient | None) -> _NatsClient:
     return client
 
 
-def _to_message(raw_message: object) -> Message:
+def _to_message(raw_message: object, topic: str = "") -> Message:
     message = cast("_NatsRawMessage", raw_message)
     headers = _headers_to_dict(message.headers)
     key = headers.pop("message-key", None)
+    # Use logical topic name if provided (when consuming via subject_prefix).
+    # Fall back to broker subject if topic not specified (e.g., direct subject subscriptions).
+    msg_topic = topic if topic else message.subject
     return Message(
         key=key,
         value=message.data,
-        topic=message.subject,
+        topic=msg_topic,
         partition=0,
         offset=0,
         timestamp=datetime.now(UTC),

--- a/packages/pykit-messaging/src/pykit_messaging/nats/producer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/producer.py
@@ -1,0 +1,124 @@
+"""NATS producer adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from collections.abc import Awaitable
+from inspect import isawaitable
+from typing import Protocol, cast
+
+from pykit_messaging.nats.config import NatsConfig
+from pykit_messaging.types import Event, JsonValue, Message
+from pykit_util import JsonCodec
+
+
+class _NatsClient(Protocol):
+    async def publish(
+        self,
+        subject: str,
+        payload: bytes = b"",
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> None: ...
+
+    async def flush(self, timeout: float | None = None) -> None: ...
+
+    def close(self) -> Awaitable[None] | None: ...
+
+    async def drain(self) -> object: ...
+
+
+class NatsProducer:
+    """NATS-backed message producer requiring the ``nats`` extra."""
+
+    def __init__(self, config: NatsConfig) -> None:
+        config.validate()
+        self._config = config
+        self._client: _NatsClient | None = None
+
+    async def start(self) -> None:
+        """Connect to NATS."""
+        if self._client is not None:
+            return
+        nats = _import_nats()
+        kwargs: dict[str, object] = {
+            "servers": self._config.servers(),
+            "connect_timeout": self._config.connect_timeout,
+            "max_reconnect_attempts": self._config.retries,
+            "reconnect_time_wait": self._config.reconnect_time_wait,
+            "allow_reconnect": self._config.allow_reconnect,
+        }
+        if self._config.token:
+            kwargs["token"] = self._config.token
+        if self._config.username:
+            kwargs["user"] = self._config.username
+            kwargs["password"] = self._config.password
+        self._client = cast("_NatsClient", await nats.connect(**kwargs))
+
+    async def send(
+        self,
+        topic: str,
+        value: bytes,
+        key: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        """Publish bytes to a NATS subject."""
+        subject = self._config.subject(topic)
+        await self.start()
+        outgoing_headers = dict(headers or {})
+        if key is not None:
+            outgoing_headers["message-key"] = key
+        await _require_client(self._client).publish(subject, value, headers=outgoing_headers or None)
+
+    async def send_event(self, topic: str, event: Event) -> None:
+        """Serialize and publish an event."""
+        await self.send(topic, event.to_json(), key=event.id, headers={"event-type": event.type})
+
+    async def send_json(self, topic: str, data: JsonValue, key: str | None = None) -> None:
+        """Serialize and publish JSON."""
+        await self.send(topic, JsonCodec[JsonValue](stringify_unknown=False).encode(data), key=key)
+
+    async def send_batch(self, messages: list[Message]) -> None:
+        """Publish messages sequentially."""
+        for message in messages:
+            await self.send(message.topic, message.value, key=message.key, headers=message.headers)
+
+    async def flush(self) -> None:
+        """Flush pending publishes."""
+        if self._client is not None:
+            await self._client.flush(timeout=self._config.request_timeout_ms / 1000)
+
+    async def close(self) -> None:
+        """Close the NATS connection."""
+        if self._client is None:
+            return
+        drain = getattr(self._client, "drain", None)
+        if self._config.drain_timeout > 0 and drain is not None:
+            try:
+                await asyncio.wait_for(drain(), timeout=self._config.drain_timeout)
+            except TimeoutError:
+                await _close_client(self._client)
+        else:
+            await _close_client(self._client)
+        self._client = None
+
+
+def _import_nats() -> object:
+    try:
+        return importlib.import_module("nats")
+    except ImportError as exc:
+        msg = "nats-py is required for NATS messaging; install pykit-messaging[nats]"
+        raise ImportError(msg) from exc
+
+
+def _require_client(client: _NatsClient | None) -> _NatsClient:
+    if client is None:
+        raise RuntimeError("NATS client is not started")
+    return client
+
+
+async def _close_client(client: _NatsClient) -> None:
+    result = client.close()
+    if isawaitable(result):
+        await result

--- a/packages/pykit-messaging/src/pykit_messaging/nats/producer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/nats/producer.py
@@ -29,6 +29,10 @@ class _NatsClient(Protocol):
     async def drain(self) -> object: ...
 
 
+class _NatsModule(Protocol):
+    def connect(self, **kwargs: object) -> Awaitable[_NatsClient]: ...
+
+
 class NatsProducer:
     """NATS-backed message producer requiring the ``nats`` extra."""
 
@@ -54,7 +58,7 @@ class NatsProducer:
         if self._config.username:
             kwargs["user"] = self._config.username
             kwargs["password"] = self._config.password
-        self._client = cast("_NatsClient", await nats.connect(**kwargs))
+        self._client = await nats.connect(**kwargs)
 
     async def send(
         self,
@@ -104,9 +108,9 @@ class NatsProducer:
         self._client = None
 
 
-def _import_nats() -> object:
+def _import_nats() -> _NatsModule:
     try:
-        return importlib.import_module("nats")
+        return cast("_NatsModule", importlib.import_module("nats"))
     except ImportError as exc:
         msg = "nats-py is required for NATS messaging; install pykit-messaging[nats]"
         raise ImportError(msg) from exc

--- a/packages/pykit-messaging/src/pykit_messaging/protocols.py
+++ b/packages/pykit-messaging/src/pykit_messaging/protocols.py
@@ -43,7 +43,7 @@ class MessageConsumer(Protocol):
 
 @runtime_checkable
 class ControllableConsumer(Protocol):
-    """Optional pause/resume capability for backends that support it."""
+    """Optional pause/resume capability for adapters that support it."""
 
     async def pause(self) -> None: ...
 

--- a/packages/pykit-messaging/src/pykit_messaging/protocols.py
+++ b/packages/pykit-messaging/src/pykit_messaging/protocols.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-from pykit_messaging.types import Event, Message, MessageHandler
+from pykit_messaging.types import Event, JsonValue, Message, MessageHandler
 
 
 @runtime_checkable
@@ -21,7 +21,7 @@ class MessageProducer(Protocol):
 
     async def send_event(self, topic: str, event: Event) -> None: ...
 
-    async def send_json(self, topic: str, data: object, key: str | None = None) -> None: ...
+    async def send_json(self, topic: str, data: JsonValue, key: str | None = None) -> None: ...
 
     async def send_batch(self, messages: list[Message]) -> None: ...
 
@@ -39,3 +39,12 @@ class MessageConsumer(Protocol):
     async def consume(self, handler: MessageHandler) -> None: ...
 
     async def close(self) -> None: ...
+
+
+@runtime_checkable
+class ControllableConsumer(Protocol):
+    """Optional pause/resume capability for backends that support it."""
+
+    async def pause(self) -> None: ...
+
+    async def resume(self) -> None: ...

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/__init__.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/__init__.py
@@ -1,0 +1,31 @@
+"""RabbitMQ provider for pykit-messaging."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import TYPE_CHECKING
+
+from pykit_messaging.config import BrokerConfig
+from pykit_messaging.rabbitmq.config import BACKEND_NAME, RabbitMqConfig
+from pykit_messaging.rabbitmq.consumer import RabbitMqConsumer
+from pykit_messaging.rabbitmq.producer import RabbitMqProducer
+
+if TYPE_CHECKING:
+    from pykit_messaging.registry import MessagingRegistry
+
+
+def register(registry: MessagingRegistry) -> None:
+    """Register config-free RabbitMQ producer and consumer factories."""
+    registry.register_producer(BACKEND_NAME, lambda config: RabbitMqProducer(_config_from(config)))
+    registry.register_consumer(BACKEND_NAME, lambda config: RabbitMqConsumer(_config_from(config)))
+
+
+def _config_from(config: BrokerConfig) -> RabbitMqConfig:
+    if isinstance(config, RabbitMqConfig):
+        config.validate()
+        return config
+    allowed = {field.name for field in fields(RabbitMqConfig)}
+    return RabbitMqConfig(**{key: value for key, value in config.__dict__.items() if key in allowed})
+
+
+__all__ = ["RabbitMqConfig", "RabbitMqConsumer", "RabbitMqProducer", "register"]

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/__init__.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/__init__.py
@@ -6,7 +6,7 @@ from dataclasses import fields
 from typing import TYPE_CHECKING
 
 from pykit_messaging.config import BrokerConfig
-from pykit_messaging.rabbitmq.config import BACKEND_NAME, RabbitMqConfig
+from pykit_messaging.rabbitmq.config import ADAPTER_NAME, RabbitMqConfig
 from pykit_messaging.rabbitmq.consumer import RabbitMqConsumer
 from pykit_messaging.rabbitmq.producer import RabbitMqProducer
 
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 
 def register(registry: MessagingRegistry) -> None:
     """Register config-free RabbitMQ producer and consumer factories."""
-    registry.register_producer(BACKEND_NAME, lambda config: RabbitMqProducer(_config_from(config)))
-    registry.register_consumer(BACKEND_NAME, lambda config: RabbitMqConsumer(_config_from(config)))
+    registry.register_producer(ADAPTER_NAME, lambda config: RabbitMqProducer(_config_from(config)))
+    registry.register_consumer(ADAPTER_NAME, lambda config: RabbitMqConsumer(_config_from(config)))
 
 
 def _config_from(config: BrokerConfig) -> RabbitMqConfig:

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/config.py
@@ -1,0 +1,96 @@
+"""RabbitMQ adapter configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+from pykit_errors import AppError
+from pykit_messaging.config import (
+    BrokerConfig,
+    CommitStrategy,
+    DeliveryGuarantee,
+    reject_exactly_once,
+    validate_topic_name,
+)
+
+BACKEND_NAME = "rabbitmq"
+DEFAULT_URL = "amqps://localhost:5671/"
+EXCHANGE_TYPES = {"direct", "fanout", "topic", "headers"}
+
+
+@dataclass
+class RabbitMqConfig(BrokerConfig):
+    """Configuration for the RabbitMQ adapter."""
+
+    backend: str = BACKEND_NAME
+    name: str = BACKEND_NAME
+    url: str = field(default=DEFAULT_URL, repr=False)
+    routing_key_prefix: str = ""
+    exchange_name: str = ""
+    exchange_type: str = "direct"
+    queue_name: str = ""
+    durable: bool = True
+    auto_delete: bool = False
+    exclusive: bool = False
+    auto_ack: bool = False
+    publisher_confirms: bool = True
+    connection_name: str = ""
+    username: str = field(default="", repr=False)
+    password: str = field(default="", repr=False)
+    allow_insecure_dev: bool = False
+
+    def validate(self) -> None:
+        """Validate RabbitMQ-specific and broker-neutral settings."""
+        super().validate()
+        reject_exactly_once(self, BACKEND_NAME)
+        if not self.url:
+            raise AppError.invalid_input("url", "RabbitMQ connection URL is required")
+        _validate_rabbitmq_url(self.url, self.allow_insecure_dev)
+        if self.routing_key_prefix:
+            validate_topic_name(self.routing_key_prefix.strip("."), "routing_key_prefix")
+        if self.queue_name:
+            validate_topic_name(self.queue_name, "queue_name")
+        if self.exchange_name:
+            validate_topic_name(self.exchange_name, "exchange_name")
+        if self.exchange_type not in EXCHANGE_TYPES:
+            raise AppError.invalid_input("exchange_type", "unsupported RabbitMQ exchange type")
+        if self.auto_ack and self.commit_strategy is not CommitStrategy.AUTO:
+            raise AppError.invalid_input("commit_strategy", "auto_ack requires commit_strategy=auto")
+        if not self.auto_ack and self.commit_strategy is CommitStrategy.AUTO:
+            raise AppError.invalid_input("auto_ack", "commit_strategy=auto requires auto_ack=True")
+        if self.delivery_guarantee is DeliveryGuarantee.AT_MOST_ONCE and not self.auto_ack:
+            raise AppError.invalid_input("auto_ack", "at-most-once delivery requires auto_ack=True")
+        if self.delivery_guarantee is DeliveryGuarantee.AT_LEAST_ONCE and self.auto_ack:
+            raise AppError.invalid_input(
+                "auto_ack", "at-least-once delivery requires explicit ack after handling"
+            )
+        if self.exclusive and self.durable:
+            raise AppError.invalid_input("exclusive", "exclusive RabbitMQ queues cannot be durable")
+        if bool(self.username) != bool(self.password):
+            raise AppError.invalid_input("auth", "RabbitMQ username and password must be provided together")
+
+    def routing_key(self, topic: str) -> str:
+        """Return topic with the configured routing key prefix applied."""
+        validate_topic_name(topic, "topic")
+        if not self.routing_key_prefix:
+            return topic
+        return f"{self.routing_key_prefix.rstrip('.')}.{topic.lstrip('.')}"
+
+    def queue_for(self, topic: str) -> str:
+        """Return the queue name for a subscribed topic."""
+        return self.queue_name or self.routing_key(topic)
+
+
+def _validate_rabbitmq_url(value: str, allow_insecure_dev: bool) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"amqp", "amqps"} or not parsed.hostname:
+        raise AppError.invalid_input("url", "RabbitMQ URL must include amqp/amqps scheme and host")
+    if parsed.username or parsed.password:
+        raise AppError.invalid_input(
+            "url", "RabbitMQ credentials must be configured via username/password, not URL userinfo"
+        )
+    if parsed.query:
+        raise AppError.invalid_input("url", "RabbitMQ URL query strings are not accepted")
+    if parsed.scheme != "amqps" and not allow_insecure_dev:
+        raise AppError.invalid_input("url", "RabbitMQ plaintext URLs require allow_insecure_dev=True")

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/config.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/config.py
@@ -14,7 +14,7 @@ from pykit_messaging.config import (
     validate_topic_name,
 )
 
-BACKEND_NAME = "rabbitmq"
+ADAPTER_NAME = "rabbitmq"
 DEFAULT_URL = "amqps://localhost:5671/"
 EXCHANGE_TYPES = {"direct", "fanout", "topic", "headers"}
 
@@ -23,8 +23,8 @@ EXCHANGE_TYPES = {"direct", "fanout", "topic", "headers"}
 class RabbitMqConfig(BrokerConfig):
     """Configuration for the RabbitMQ adapter."""
 
-    backend: str = BACKEND_NAME
-    name: str = BACKEND_NAME
+    adapter: str = ADAPTER_NAME
+    name: str = ADAPTER_NAME
     url: str = field(default=DEFAULT_URL, repr=False)
     routing_key_prefix: str = ""
     exchange_name: str = ""
@@ -43,7 +43,7 @@ class RabbitMqConfig(BrokerConfig):
     def validate(self) -> None:
         """Validate RabbitMQ-specific and broker-neutral settings."""
         super().validate()
-        reject_exactly_once(self, BACKEND_NAME)
+        reject_exactly_once(self, ADAPTER_NAME)
         if not self.url:
             raise AppError.invalid_input("url", "RabbitMQ connection URL is required")
         _validate_rabbitmq_url(self.url, self.allow_insecure_dev)

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/consumer.py
@@ -1,0 +1,176 @@
+"""RabbitMQ consumer adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from datetime import UTC, datetime
+from typing import Protocol, cast
+
+from pykit_messaging.rabbitmq.config import RabbitMqConfig
+from pykit_messaging.types import Message, MessageHandler
+
+
+class _RabbitRawMessage(Protocol):
+    body: bytes
+    routing_key: str
+    correlation_id: str | None
+    headers: object | None
+
+    def process(self) -> object: ...
+
+
+class _Exchange(Protocol):
+    async def publish(self, message: object, *, routing_key: str) -> object: ...
+
+
+class _Queue(Protocol):
+    async def bind(self, exchange: _Exchange, *, routing_key: str) -> object: ...
+
+    async def consume(self, callback: object, *, no_ack: bool = False) -> str: ...
+
+    async def cancel(self, consumer_tag: str) -> object: ...
+
+
+class _Channel(Protocol):
+    default_exchange: _Exchange
+
+    async def set_qos(self, *, prefetch_count: int) -> object: ...
+
+    async def declare_exchange(self, name: str, exchange_type: object, *, durable: bool) -> _Exchange: ...
+
+    async def declare_queue(
+        self,
+        name: str,
+        *,
+        durable: bool,
+        auto_delete: bool = False,
+        exclusive: bool = False,
+    ) -> _Queue: ...
+
+    async def close(self) -> object: ...
+
+
+class _Connection(Protocol):
+    async def channel(self, *, publisher_confirms: bool = True) -> _Channel: ...
+
+    async def close(self) -> object: ...
+
+
+class RabbitMqConsumer:
+    """RabbitMQ-backed consumer requiring the ``rabbitmq`` extra."""
+
+    def __init__(self, config: RabbitMqConfig) -> None:
+        config.validate()
+        self._config = config
+        self._topics = list(config.topics)
+        self._aio_pika: object | None = None
+        self._connection: _Connection | None = None
+        self._channel: _Channel | None = None
+        self._exchange: _Exchange | None = None
+        self._consumer_tags: list[tuple[_Queue, str]] = []
+        self._closed = asyncio.Event()
+
+    async def start(self) -> None:
+        """Connect to RabbitMQ and open a consuming channel."""
+        if self._connection is not None:
+            return
+        aio_pika = _import_aio_pika()
+        self._aio_pika = aio_pika
+        connect_kwargs: dict[str, object] = {"timeout": self._config.request_timeout_ms / 1000}
+        if self._config.username:
+            connect_kwargs["login"] = self._config.username
+            connect_kwargs["password"] = self._config.password
+        if self._config.connection_name:
+            connect_kwargs["client_properties"] = {"connection_name": self._config.connection_name}
+        self._connection = cast(
+            "_Connection", await aio_pika.connect_robust(self._config.url, **connect_kwargs)
+        )
+        self._channel = await self._connection.channel(publisher_confirms=False)
+        await self._channel.set_qos(prefetch_count=self._config.max_in_flight)
+        self._exchange = await _resolve_exchange(aio_pika, self._channel, self._config)
+        self._closed.clear()
+
+    async def subscribe(self, topics: list[str]) -> None:
+        """Set queue names/routing keys consumed by this consumer."""
+        self._topics = list(topics)
+
+    async def consume(self, handler: MessageHandler) -> None:
+        """Consume configured queues until closed."""
+        await self.start()
+        channel = _require_channel(self._channel)
+        exchange = _require_exchange(self._exchange)
+
+        async def _callback(raw_message: object) -> None:
+            message = cast("_RabbitRawMessage", raw_message)
+            if self._config.auto_ack:
+                await handler(_to_message(message))
+                return
+            async with message.process():
+                await handler(_to_message(message))
+
+        for topic in self._topics:
+            queue = await channel.declare_queue(
+                self._config.queue_for(topic),
+                durable=self._config.durable,
+                auto_delete=self._config.auto_delete,
+                exclusive=self._config.exclusive,
+            )
+            if self._config.exchange_name:
+                await queue.bind(exchange, routing_key=self._config.routing_key(topic))
+            self._consumer_tags.append((queue, await queue.consume(_callback, no_ack=self._config.auto_ack)))
+        await self._closed.wait()
+
+    async def close(self) -> None:
+        """Cancel consumers and close the RabbitMQ connection."""
+        self._closed.set()
+        for queue, consumer_tag in self._consumer_tags:
+            await queue.cancel(consumer_tag)
+        self._consumer_tags.clear()
+        if self._channel is not None:
+            await self._channel.close()
+            self._channel = None
+        if self._connection is not None:
+            await self._connection.close()
+            self._connection = None
+        self._exchange = None
+
+
+def _import_aio_pika() -> object:
+    try:
+        return importlib.import_module("aio_pika")
+    except ImportError as exc:
+        msg = "aio-pika is required for RabbitMQ messaging; install pykit-messaging[rabbitmq]"
+        raise ImportError(msg) from exc
+
+
+async def _resolve_exchange(aio_pika: object, channel: _Channel, config: RabbitMqConfig) -> _Exchange:
+    if not config.exchange_name:
+        return channel.default_exchange
+    exchange_type = getattr(aio_pika.ExchangeType, config.exchange_type.upper())
+    return await channel.declare_exchange(config.exchange_name, exchange_type, durable=config.durable)
+
+
+def _require_channel(channel: _Channel | None) -> _Channel:
+    if channel is None:
+        raise RuntimeError("RabbitMQ channel is not started")
+    return channel
+
+
+def _require_exchange(exchange: _Exchange | None) -> _Exchange:
+    if exchange is None:
+        raise RuntimeError("RabbitMQ exchange is not started")
+    return exchange
+
+
+def _to_message(raw_message: _RabbitRawMessage) -> Message:
+    headers = {str(k): str(v) for k, v in dict(raw_message.headers or {}).items()}
+    return Message(
+        key=raw_message.correlation_id,
+        value=raw_message.body,
+        topic=raw_message.routing_key,
+        partition=0,
+        offset=0,
+        timestamp=datetime.now(UTC),
+        headers=headers,
+    )

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/consumer.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+from collections.abc import Awaitable, Mapping
 from datetime import UTC, datetime
+from types import TracebackType
 from typing import Protocol, cast
 
 from pykit_messaging.rabbitmq.config import RabbitMqConfig
@@ -17,7 +19,18 @@ class _RabbitRawMessage(Protocol):
     correlation_id: str | None
     headers: object | None
 
-    def process(self) -> object: ...
+    def process(self) -> _RabbitMessageProcess: ...
+
+
+class _RabbitMessageProcess(Protocol):
+    async def __aenter__(self) -> object: ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> object: ...
 
 
 class _Exchange(Protocol):
@@ -57,6 +70,12 @@ class _Connection(Protocol):
     async def close(self) -> object: ...
 
 
+class _AioPikaModule(Protocol):
+    ExchangeType: object
+
+    def connect_robust(self, url: str, **kwargs: object) -> Awaitable[_Connection]: ...
+
+
 class RabbitMqConsumer:
     """RabbitMQ-backed consumer requiring the ``rabbitmq`` extra."""
 
@@ -64,7 +83,7 @@ class RabbitMqConsumer:
         config.validate()
         self._config = config
         self._topics = list(config.topics)
-        self._aio_pika: object | None = None
+        self._aio_pika: _AioPikaModule | None = None
         self._connection: _Connection | None = None
         self._channel: _Channel | None = None
         self._exchange: _Exchange | None = None
@@ -83,9 +102,7 @@ class RabbitMqConsumer:
             connect_kwargs["password"] = self._config.password
         if self._config.connection_name:
             connect_kwargs["client_properties"] = {"connection_name": self._config.connection_name}
-        self._connection = cast(
-            "_Connection", await aio_pika.connect_robust(self._config.url, **connect_kwargs)
-        )
+        self._connection = await aio_pika.connect_robust(self._config.url, **connect_kwargs)
         self._channel = await self._connection.channel(publisher_confirms=False)
         await self._channel.set_qos(prefetch_count=self._config.max_in_flight)
         self._exchange = await _resolve_exchange(aio_pika, self._channel, self._config)
@@ -136,15 +153,15 @@ class RabbitMqConsumer:
         self._exchange = None
 
 
-def _import_aio_pika() -> object:
+def _import_aio_pika() -> _AioPikaModule:
     try:
-        return importlib.import_module("aio_pika")
+        return cast("_AioPikaModule", importlib.import_module("aio_pika"))
     except ImportError as exc:
         msg = "aio-pika is required for RabbitMQ messaging; install pykit-messaging[rabbitmq]"
         raise ImportError(msg) from exc
 
 
-async def _resolve_exchange(aio_pika: object, channel: _Channel, config: RabbitMqConfig) -> _Exchange:
+async def _resolve_exchange(aio_pika: _AioPikaModule, channel: _Channel, config: RabbitMqConfig) -> _Exchange:
     if not config.exchange_name:
         return channel.default_exchange
     exchange_type = getattr(aio_pika.ExchangeType, config.exchange_type.upper())
@@ -164,7 +181,7 @@ def _require_exchange(exchange: _Exchange | None) -> _Exchange:
 
 
 def _to_message(raw_message: _RabbitRawMessage) -> Message:
-    headers = {str(k): str(v) for k, v in dict(raw_message.headers or {}).items()}
+    headers = _headers_to_dict(raw_message.headers)
     return Message(
         key=raw_message.correlation_id,
         value=raw_message.body,
@@ -174,3 +191,10 @@ def _to_message(raw_message: _RabbitRawMessage) -> Message:
         timestamp=datetime.now(UTC),
         headers=headers,
     )
+
+
+def _headers_to_dict(raw_headers: object | None) -> dict[str, str]:
+    if raw_headers is None or not isinstance(raw_headers, Mapping):
+        return {}
+    headers_map = cast("Mapping[object, object]", raw_headers)
+    return {str(key): str(value) for key, value in headers_map.items()}

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/consumer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/consumer.py
@@ -82,7 +82,7 @@ class RabbitMqConsumer:
     def __init__(self, config: RabbitMqConfig) -> None:
         config.validate()
         self._config = config
-        self._topics = list(config.topics)
+        self._topics = list(config.topics or config.subscriptions)
         self._aio_pika: _AioPikaModule | None = None
         self._connection: _Connection | None = None
         self._channel: _Channel | None = None
@@ -118,13 +118,13 @@ class RabbitMqConsumer:
         channel = _require_channel(self._channel)
         exchange = _require_exchange(self._exchange)
 
-        async def _callback(raw_message: object) -> None:
+        async def _handle(raw_message: object, logical_topic: str) -> None:
             message = cast("_RabbitRawMessage", raw_message)
             if self._config.auto_ack:
-                await handler(_to_message(message))
+                await handler(_to_message(message, logical_topic))
                 return
             async with message.process():
-                await handler(_to_message(message))
+                await handler(_to_message(message, logical_topic))
 
         for topic in self._topics:
             queue = await channel.declare_queue(
@@ -135,6 +135,10 @@ class RabbitMqConsumer:
             )
             if self._config.exchange_name:
                 await queue.bind(exchange, routing_key=self._config.routing_key(topic))
+
+            async def _callback(raw_message: object, logical_topic: str = topic) -> None:
+                await _handle(raw_message, logical_topic)
+
             self._consumer_tags.append((queue, await queue.consume(_callback, no_ack=self._config.auto_ack)))
         await self._closed.wait()
 
@@ -180,12 +184,12 @@ def _require_exchange(exchange: _Exchange | None) -> _Exchange:
     return exchange
 
 
-def _to_message(raw_message: _RabbitRawMessage) -> Message:
+def _to_message(raw_message: _RabbitRawMessage, logical_topic: str) -> Message:
     headers = _headers_to_dict(raw_message.headers)
     return Message(
         key=raw_message.correlation_id,
         value=raw_message.body,
-        topic=raw_message.routing_key,
+        topic=logical_topic,
         partition=0,
         offset=0,
         timestamp=datetime.now(UTC),

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/producer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/producer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Awaitable, Callable
 from typing import Protocol, cast
 
 from pykit_messaging.rabbitmq.config import RabbitMqConfig
@@ -28,13 +29,25 @@ class _Connection(Protocol):
     async def close(self) -> object: ...
 
 
+class _DeliveryMode(Protocol):
+    PERSISTENT: object
+
+
+class _AioPikaModule(Protocol):
+    Message: Callable[..., object]
+    DeliveryMode: _DeliveryMode
+    ExchangeType: object
+
+    def connect_robust(self, url: str, **kwargs: object) -> Awaitable[_Connection]: ...
+
+
 class RabbitMqProducer:
     """RabbitMQ-backed producer requiring the ``rabbitmq`` extra."""
 
     def __init__(self, config: RabbitMqConfig) -> None:
         config.validate()
         self._config = config
-        self._aio_pika: object | None = None
+        self._aio_pika: _AioPikaModule | None = None
         self._connection: _Connection | None = None
         self._channel: _Channel | None = None
         self._exchange: _Exchange | None = None
@@ -51,9 +64,7 @@ class RabbitMqProducer:
             connect_kwargs["password"] = self._config.password
         if self._config.connection_name:
             connect_kwargs["client_properties"] = {"connection_name": self._config.connection_name}
-        self._connection = cast(
-            "_Connection", await aio_pika.connect_robust(self._config.url, **connect_kwargs)
-        )
+        self._connection = await aio_pika.connect_robust(self._config.url, **connect_kwargs)
         self._channel = await self._connection.channel(publisher_confirms=self._config.publisher_confirms)
         self._exchange = await _resolve_exchange(aio_pika, self._channel, self._config)
 
@@ -104,22 +115,22 @@ class RabbitMqProducer:
         self._exchange = None
 
 
-def _import_aio_pika() -> object:
+def _import_aio_pika() -> _AioPikaModule:
     try:
-        return importlib.import_module("aio_pika")
+        return cast("_AioPikaModule", importlib.import_module("aio_pika"))
     except ImportError as exc:
         msg = "aio-pika is required for RabbitMQ messaging; install pykit-messaging[rabbitmq]"
         raise ImportError(msg) from exc
 
 
-async def _resolve_exchange(aio_pika: object, channel: _Channel, config: RabbitMqConfig) -> _Exchange:
+async def _resolve_exchange(aio_pika: _AioPikaModule, channel: _Channel, config: RabbitMqConfig) -> _Exchange:
     if not config.exchange_name:
         return channel.default_exchange
     exchange_type = getattr(aio_pika.ExchangeType, config.exchange_type.upper())
     return await channel.declare_exchange(config.exchange_name, exchange_type, durable=config.durable)
 
 
-def _require_module(module: object | None) -> object:
+def _require_module(module: _AioPikaModule | None) -> _AioPikaModule:
     if module is None:
         raise RuntimeError("aio-pika is not loaded")
     return module

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/producer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/producer.py
@@ -76,7 +76,7 @@ class RabbitMqProducer:
         headers: dict[str, str] | None = None,
     ) -> None:
         """Publish bytes using *topic* as the routing key."""
-        routing_key = self._config.routing_key(topic)
+        routing_key = self._publish_routing_key(topic)
         await self.start()
         aio_pika = _require_module(self._aio_pika)
         exchange = _require_exchange(self._exchange)
@@ -113,6 +113,11 @@ class RabbitMqProducer:
             await self._connection.close()
             self._connection = None
         self._exchange = None
+
+    def _publish_routing_key(self, topic: str) -> str:
+        if not self._config.exchange_name:
+            return self._config.queue_for(topic)
+        return self._config.routing_key(topic)
 
 
 def _import_aio_pika() -> _AioPikaModule:

--- a/packages/pykit-messaging/src/pykit_messaging/rabbitmq/producer.py
+++ b/packages/pykit-messaging/src/pykit_messaging/rabbitmq/producer.py
@@ -1,0 +1,131 @@
+"""RabbitMQ producer adapter."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Protocol, cast
+
+from pykit_messaging.rabbitmq.config import RabbitMqConfig
+from pykit_messaging.types import Event, JsonValue, Message
+from pykit_util import JsonCodec
+
+
+class _Exchange(Protocol):
+    async def publish(self, message: object, *, routing_key: str) -> object: ...
+
+
+class _Channel(Protocol):
+    default_exchange: _Exchange
+
+    async def declare_exchange(self, name: str, exchange_type: object, *, durable: bool) -> _Exchange: ...
+
+    async def close(self) -> object: ...
+
+
+class _Connection(Protocol):
+    async def channel(self, *, publisher_confirms: bool = True) -> _Channel: ...
+
+    async def close(self) -> object: ...
+
+
+class RabbitMqProducer:
+    """RabbitMQ-backed producer requiring the ``rabbitmq`` extra."""
+
+    def __init__(self, config: RabbitMqConfig) -> None:
+        config.validate()
+        self._config = config
+        self._aio_pika: object | None = None
+        self._connection: _Connection | None = None
+        self._channel: _Channel | None = None
+        self._exchange: _Exchange | None = None
+
+    async def start(self) -> None:
+        """Connect to RabbitMQ and open a channel."""
+        if self._connection is not None:
+            return
+        aio_pika = _import_aio_pika()
+        self._aio_pika = aio_pika
+        connect_kwargs: dict[str, object] = {"timeout": self._config.request_timeout_ms / 1000}
+        if self._config.username:
+            connect_kwargs["login"] = self._config.username
+            connect_kwargs["password"] = self._config.password
+        if self._config.connection_name:
+            connect_kwargs["client_properties"] = {"connection_name": self._config.connection_name}
+        self._connection = cast(
+            "_Connection", await aio_pika.connect_robust(self._config.url, **connect_kwargs)
+        )
+        self._channel = await self._connection.channel(publisher_confirms=self._config.publisher_confirms)
+        self._exchange = await _resolve_exchange(aio_pika, self._channel, self._config)
+
+    async def send(
+        self,
+        topic: str,
+        value: bytes,
+        key: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        """Publish bytes using *topic* as the routing key."""
+        routing_key = self._config.routing_key(topic)
+        await self.start()
+        aio_pika = _require_module(self._aio_pika)
+        exchange = _require_exchange(self._exchange)
+        message = aio_pika.Message(
+            body=value,
+            headers=dict(headers or {}),
+            correlation_id=key,
+            delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+        )
+        await exchange.publish(message, routing_key=routing_key)
+
+    async def send_event(self, topic: str, event: Event) -> None:
+        """Serialize and publish an event."""
+        await self.send(topic, event.to_json(), key=event.id, headers={"event-type": event.type})
+
+    async def send_json(self, topic: str, data: JsonValue, key: str | None = None) -> None:
+        """Serialize and publish JSON."""
+        await self.send(topic, JsonCodec[JsonValue](stringify_unknown=False).encode(data), key=key)
+
+    async def send_batch(self, messages: list[Message]) -> None:
+        """Publish messages sequentially."""
+        for message in messages:
+            await self.send(message.topic, message.value, key=message.key, headers=message.headers)
+
+    async def flush(self) -> None:
+        """No-op; publisher confirms await broker acceptance per publish."""
+
+    async def close(self) -> None:
+        """Close the RabbitMQ channel and connection."""
+        if self._channel is not None:
+            await self._channel.close()
+            self._channel = None
+        if self._connection is not None:
+            await self._connection.close()
+            self._connection = None
+        self._exchange = None
+
+
+def _import_aio_pika() -> object:
+    try:
+        return importlib.import_module("aio_pika")
+    except ImportError as exc:
+        msg = "aio-pika is required for RabbitMQ messaging; install pykit-messaging[rabbitmq]"
+        raise ImportError(msg) from exc
+
+
+async def _resolve_exchange(aio_pika: object, channel: _Channel, config: RabbitMqConfig) -> _Exchange:
+    if not config.exchange_name:
+        return channel.default_exchange
+    exchange_type = getattr(aio_pika.ExchangeType, config.exchange_type.upper())
+    return await channel.declare_exchange(config.exchange_name, exchange_type, durable=config.durable)
+
+
+def _require_module(module: object | None) -> object:
+    if module is None:
+        raise RuntimeError("aio-pika is not loaded")
+    return module
+
+
+def _require_exchange(exchange: _Exchange | None) -> _Exchange:
+    if exchange is None:
+        raise RuntimeError("RabbitMQ exchange is not started")
+    return exchange

--- a/packages/pykit-messaging/src/pykit_messaging/registry.py
+++ b/packages/pykit-messaging/src/pykit_messaging/registry.py
@@ -1,0 +1,89 @@
+"""Explicit messaging backend registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pykit_errors import AppError
+from pykit_messaging.config import BrokerConfig
+from pykit_messaging.protocols import MessageConsumer, MessageProducer
+
+ProducerFactory = Callable[[BrokerConfig], MessageProducer]
+ConsumerFactory = Callable[[BrokerConfig], MessageConsumer]
+BackendStateCleanup = Callable[[], None]
+
+
+class MessagingRegistry:
+    """Application-owned messaging backend registry.
+
+    Backends are registered explicitly by composition code. Registration is
+    config-free; each create call selects the backend from ``config.backend``
+    and passes the full config to the registered factory.
+    """
+
+    def __init__(self) -> None:
+        self._producers: dict[str, ProducerFactory] = {}
+        self._consumers: dict[str, ConsumerFactory] = {}
+        self._state_cleanups: dict[str, BackendStateCleanup] = {}
+
+    def register_producer(self, backend: str, factory: ProducerFactory) -> None:
+        """Register a producer factory for *backend*."""
+        if not backend:
+            raise AppError.invalid_input("backend", "messaging backend name is required")
+        if backend in self._producers:
+            raise AppError.already_exists(f"messaging producer backend '{backend}'")
+        self._producers[backend] = factory
+
+    def register_consumer(self, backend: str, factory: ConsumerFactory) -> None:
+        """Register a consumer factory for *backend*."""
+        if not backend:
+            raise AppError.invalid_input("backend", "messaging backend name is required")
+        if backend in self._consumers:
+            raise AppError.already_exists(f"messaging consumer backend '{backend}'")
+        self._consumers[backend] = factory
+
+    def register_backend_state_cleanup(self, backend: str, cleanup: BackendStateCleanup) -> None:
+        """Register a callback that clears per-backend runtime state."""
+        if not backend:
+            raise AppError.invalid_input("backend", "messaging backend name is required")
+        self._state_cleanups[backend] = cleanup
+
+    def clear_backend_state(self, backend: str | None = None) -> None:
+        """Clear runtime state for one backend, or all backends when omitted."""
+        if backend is None:
+            for cleanup in self._state_cleanups.values():
+                cleanup()
+            return
+        cleanup = self._state_cleanups.get(backend)
+        if cleanup is not None:
+            cleanup()
+
+    def producer(self, config: BrokerConfig) -> MessageProducer:
+        """Create a producer for ``config.backend`` using *config*."""
+        config.validate()
+        if not config.enabled:
+            raise AppError.invalid_input("enabled", "messaging backend config is disabled")
+        try:
+            factory = self._producers[config.backend]
+        except KeyError as exc:
+            raise AppError.not_found(f"messaging producer backend '{config.backend}'") from exc
+        return factory(config)
+
+    def consumer(self, config: BrokerConfig) -> MessageConsumer:
+        """Create a consumer for ``config.backend`` using *config*."""
+        config.validate()
+        if not config.enabled:
+            raise AppError.invalid_input("enabled", "messaging backend config is disabled")
+        try:
+            factory = self._consumers[config.backend]
+        except KeyError as exc:
+            raise AppError.not_found(f"messaging consumer backend '{config.backend}'") from exc
+        return factory(config)
+
+    def producer_backends(self) -> list[str]:
+        """Return registered producer backend names."""
+        return sorted(self._producers)
+
+    def consumer_backends(self) -> list[str]:
+        """Return registered consumer backend names."""
+        return sorted(self._consumers)

--- a/packages/pykit-messaging/src/pykit_messaging/registry.py
+++ b/packages/pykit-messaging/src/pykit_messaging/registry.py
@@ -54,9 +54,9 @@ class MessagingRegistry:
             for cleanup in self._state_cleanups.values():
                 cleanup()
             return
-        cleanup = self._state_cleanups.get(backend)
-        if cleanup is not None:
-            cleanup()
+        selected_cleanup = self._state_cleanups.get(backend)
+        if selected_cleanup is not None:
+            selected_cleanup()
 
     def producer(self, config: BrokerConfig) -> MessageProducer:
         """Create a producer for ``config.backend`` using *config*."""

--- a/packages/pykit-messaging/src/pykit_messaging/registry.py
+++ b/packages/pykit-messaging/src/pykit_messaging/registry.py
@@ -1,4 +1,4 @@
-"""Explicit messaging backend registry."""
+"""Explicit messaging adapter registry."""
 
 from __future__ import annotations
 
@@ -10,80 +10,80 @@ from pykit_messaging.protocols import MessageConsumer, MessageProducer
 
 ProducerFactory = Callable[[BrokerConfig], MessageProducer]
 ConsumerFactory = Callable[[BrokerConfig], MessageConsumer]
-BackendStateCleanup = Callable[[], None]
+AdapterStateCleanup = Callable[[], None]
 
 
 class MessagingRegistry:
-    """Application-owned messaging backend registry.
+    """Application-owned messaging adapter registry.
 
-    Backends are registered explicitly by composition code. Registration is
-    config-free; each create call selects the backend from ``config.backend``
+    Adapters are registered explicitly by composition code. Registration is
+    config-free; each create call selects the adapter from ``config.adapter``
     and passes the full config to the registered factory.
     """
 
     def __init__(self) -> None:
         self._producers: dict[str, ProducerFactory] = {}
         self._consumers: dict[str, ConsumerFactory] = {}
-        self._state_cleanups: dict[str, BackendStateCleanup] = {}
+        self._state_cleanups: dict[str, AdapterStateCleanup] = {}
 
-    def register_producer(self, backend: str, factory: ProducerFactory) -> None:
-        """Register a producer factory for *backend*."""
-        if not backend:
-            raise AppError.invalid_input("backend", "messaging backend name is required")
-        if backend in self._producers:
-            raise AppError.already_exists(f"messaging producer backend '{backend}'")
-        self._producers[backend] = factory
+    def register_producer(self, adapter: str, factory: ProducerFactory) -> None:
+        """Register a producer factory for *adapter*."""
+        if not adapter:
+            raise AppError.invalid_input("adapter", "messaging adapter name is required")
+        if adapter in self._producers:
+            raise AppError.already_exists(f"messaging producer adapter '{adapter}'")
+        self._producers[adapter] = factory
 
-    def register_consumer(self, backend: str, factory: ConsumerFactory) -> None:
-        """Register a consumer factory for *backend*."""
-        if not backend:
-            raise AppError.invalid_input("backend", "messaging backend name is required")
-        if backend in self._consumers:
-            raise AppError.already_exists(f"messaging consumer backend '{backend}'")
-        self._consumers[backend] = factory
+    def register_consumer(self, adapter: str, factory: ConsumerFactory) -> None:
+        """Register a consumer factory for *adapter*."""
+        if not adapter:
+            raise AppError.invalid_input("adapter", "messaging adapter name is required")
+        if adapter in self._consumers:
+            raise AppError.already_exists(f"messaging consumer adapter '{adapter}'")
+        self._consumers[adapter] = factory
 
-    def register_backend_state_cleanup(self, backend: str, cleanup: BackendStateCleanup) -> None:
-        """Register a callback that clears per-backend runtime state."""
-        if not backend:
-            raise AppError.invalid_input("backend", "messaging backend name is required")
-        self._state_cleanups[backend] = cleanup
+    def register_adapter_state_cleanup(self, adapter: str, cleanup: AdapterStateCleanup) -> None:
+        """Register a callback that clears per-adapter runtime state."""
+        if not adapter:
+            raise AppError.invalid_input("adapter", "messaging adapter name is required")
+        self._state_cleanups[adapter] = cleanup
 
-    def clear_backend_state(self, backend: str | None = None) -> None:
-        """Clear runtime state for one backend, or all backends when omitted."""
-        if backend is None:
+    def clear_adapter_state(self, adapter: str | None = None) -> None:
+        """Clear runtime state for one adapter, or all adapters when omitted."""
+        if adapter is None:
             for cleanup in self._state_cleanups.values():
                 cleanup()
             return
-        selected_cleanup = self._state_cleanups.get(backend)
+        selected_cleanup = self._state_cleanups.get(adapter)
         if selected_cleanup is not None:
             selected_cleanup()
 
     def producer(self, config: BrokerConfig) -> MessageProducer:
-        """Create a producer for ``config.backend`` using *config*."""
+        """Create a producer for ``config.adapter`` using *config*."""
         config.validate()
         if not config.enabled:
-            raise AppError.invalid_input("enabled", "messaging backend config is disabled")
+            raise AppError.invalid_input("enabled", "messaging adapter config is disabled")
         try:
-            factory = self._producers[config.backend]
+            factory = self._producers[config.adapter]
         except KeyError as exc:
-            raise AppError.not_found(f"messaging producer backend '{config.backend}'") from exc
+            raise AppError.not_found(f"messaging producer adapter '{config.adapter}'") from exc
         return factory(config)
 
     def consumer(self, config: BrokerConfig) -> MessageConsumer:
-        """Create a consumer for ``config.backend`` using *config*."""
+        """Create a consumer for ``config.adapter`` using *config*."""
         config.validate()
         if not config.enabled:
-            raise AppError.invalid_input("enabled", "messaging backend config is disabled")
+            raise AppError.invalid_input("enabled", "messaging adapter config is disabled")
         try:
-            factory = self._consumers[config.backend]
+            factory = self._consumers[config.adapter]
         except KeyError as exc:
-            raise AppError.not_found(f"messaging consumer backend '{config.backend}'") from exc
+            raise AppError.not_found(f"messaging consumer adapter '{config.adapter}'") from exc
         return factory(config)
 
-    def producer_backends(self) -> list[str]:
-        """Return registered producer backend names."""
+    def producer_adapters(self) -> list[str]:
+        """Return registered producer adapter names."""
         return sorted(self._producers)
 
-    def consumer_backends(self) -> list[str]:
-        """Return registered consumer backend names."""
+    def consumer_adapters(self) -> list[str]:
+        """Return registered consumer adapter names."""
         return sorted(self._consumers)

--- a/packages/pykit-messaging/src/pykit_messaging/translator.py
+++ b/packages/pykit-messaging/src/pykit_messaging/translator.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Protocol, TypeVar, runtime_checkable
 
+from pykit_messaging.types import JsonValue
 from pykit_util import JsonCodec
 
 T = TypeVar("T")
@@ -48,10 +49,10 @@ class JsonTranslator:
     Serializes Python dicts to JSON bytes and deserializes JSON bytes back to dicts.
     """
 
-    def __init__(self, codec: JsonCodec[dict[str, Any]] | None = None) -> None:
+    def __init__(self, codec: JsonCodec[dict[str, JsonValue]] | None = None) -> None:
         self._codec = codec or JsonCodec()
 
-    def serialize(self, domain: dict[str, Any]) -> bytes:
+    def serialize(self, domain: dict[str, JsonValue]) -> bytes:
         """Serialize a dict to JSON bytes.
 
         Args:
@@ -62,7 +63,7 @@ class JsonTranslator:
         """
         return self._codec.encode(domain)
 
-    def deserialize(self, raw: bytes) -> dict[str, Any]:
+    def deserialize(self, raw: bytes) -> dict[str, JsonValue]:
         """Deserialize JSON bytes to a dict.
 
         Args:

--- a/packages/pykit-messaging/src/pykit_messaging/types.py
+++ b/packages/pykit-messaging/src/pykit_messaging/types.py
@@ -55,18 +55,32 @@ class Event:
     @classmethod
     def from_json(cls, raw: bytes) -> Event:
         """Deserialize event from JSON bytes."""
-        d = JsonCodec[dict[str, JsonValue]]().decode(raw)
+        payload = JsonCodec[dict[str, JsonValue]]().decode(raw)
         return cls(
-            id=d["id"],
-            type=d["type"],
-            source=d["source"],
-            timestamp=datetime.fromisoformat(d["timestamp"]),
-            subject=d.get("subject", ""),
-            content_type=d.get("content_type", "application/json"),
-            version=d.get("version", "1.0"),
-            data=d.get("data"),
+            id=_required_str(payload, "id"),
+            type=_required_str(payload, "type"),
+            source=_required_str(payload, "source"),
+            timestamp=datetime.fromisoformat(_required_str(payload, "timestamp")),
+            subject=_optional_str(payload, "subject", ""),
+            content_type=_optional_str(payload, "content_type", "application/json"),
+            version=_optional_str(payload, "version", "1.0"),
+            data=payload.get("data"),
         )
 
 
 MessageHandler = Callable[[Message], Awaitable[None]]
 EventHandler = Callable[[Event], Awaitable[None]]
+
+
+def _required_str(payload: dict[str, JsonValue], key: str) -> str:
+    value = payload[key]
+    if not isinstance(value, str):
+        raise ValueError(f"event field '{key}' must be a string")
+    return value
+
+
+def _optional_str(payload: dict[str, JsonValue], key: str, default: str) -> str:
+    value = payload.get(key, default)
+    if not isinstance(value, str):
+        raise ValueError(f"event field '{key}' must be a string")
+    return value

--- a/packages/pykit-messaging/src/pykit_messaging/types.py
+++ b/packages/pykit-messaging/src/pykit_messaging/types.py
@@ -6,9 +6,10 @@ import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
 
 from pykit_util import JsonCodec
+
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 
 
 @dataclass
@@ -33,13 +34,13 @@ class Event:
     subject: str = ""
     content_type: str = "application/json"
     version: str = "1.0"
-    data: Any = None
+    data: JsonValue = None
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     def to_json(self) -> bytes:
         """Serialize event to JSON bytes."""
-        payload: dict[str, Any] = {
+        payload: dict[str, JsonValue] = {
             "id": self.id,
             "type": self.type,
             "source": self.source,
@@ -49,12 +50,12 @@ class Event:
             "timestamp": self.timestamp.isoformat(),
             "data": self.data,
         }
-        return JsonCodec[dict[str, Any]](stringify_unknown=False).encode(payload)
+        return JsonCodec[dict[str, JsonValue]](stringify_unknown=False).encode(payload)
 
     @classmethod
     def from_json(cls, raw: bytes) -> Event:
         """Deserialize event from JSON bytes."""
-        d = JsonCodec[dict[str, Any]]().decode(raw)
+        d = JsonCodec[dict[str, JsonValue]]().decode(raw)
         return cls(
             id=d["id"],
             type=d["type"],

--- a/packages/pykit-messaging/tests/kafka_middleware/test_kafka_deadletter.py
+++ b/packages/pykit-messaging/tests/kafka_middleware/test_kafka_deadletter.py
@@ -61,15 +61,29 @@ class TestDeadLetterProducer:
         envelope = json.loads(mock_producer.send.call_args[1]["value"])
         assert envelope["retry_count"] == 3
 
-    async def test_preserves_original_headers(self) -> None:
+    async def test_preserves_safe_headers_and_redacts_sensitive_headers(self) -> None:
         mock_producer = AsyncMock()
         dlq = DeadLetterProducer(mock_producer)
 
-        msg = _make_msg(headers={"x-retry-count": "1", "trace-id": "abc"})
+        msg = _make_msg(headers={"x-retry-count": "1", "trace-id": "abc", "authorization": "Bearer secret"})
         await dlq.send(msg, RuntimeError("err"))
 
         envelope = json.loads(mock_producer.send.call_args[1]["value"])
         assert envelope["headers"]["trace-id"] == "abc"
+        assert envelope["headers"]["authorization"] == "<redacted>"
+        assert "secret" not in mock_producer.send.call_args[1]["value"].decode()
+
+    async def test_redacts_sensitive_error_and_truncates_payload(self) -> None:
+        mock_producer = AsyncMock()
+        dlq = DeadLetterProducer(mock_producer)
+
+        msg = _make_msg(value=b"x" * 5000)
+        await dlq.send(msg, RuntimeError("password=secret"))
+
+        envelope = json.loads(mock_producer.send.call_args[1]["value"])
+        assert envelope["error"] == "<redacted>"
+        assert len(envelope["payload"]) == 4097
+        assert envelope["payload"].endswith("…")
 
     async def test_default_key_when_none(self) -> None:
         mock_producer = AsyncMock()

--- a/packages/pykit-messaging/tests/kafka_middleware/test_kafka_middleware_extended.py
+++ b/packages/pykit-messaging/tests/kafka_middleware/test_kafka_middleware_extended.py
@@ -19,7 +19,6 @@ from pykit_messaging.kafka.middleware.metrics import InstrumentHandler
 from pykit_messaging.kafka.middleware.retry import (
     RetryHandler,
     RetryMiddlewareConfig,
-    _calculate_backoff,
 )
 from pykit_messaging.kafka.middleware.tracing import (
     TracingHandler,
@@ -27,6 +26,7 @@ from pykit_messaging.kafka.middleware.tracing import (
     inject_trace_context,
 )
 from pykit_messaging.types import Message
+from pykit_resilience import calculate_backoff
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -67,35 +67,35 @@ def _get_sample_value(name: str, labels: dict[str, str]) -> float | None:
 class TestCalculateBackoff:
     def test_first_attempt_equals_initial_backoff(self) -> None:
         cfg = RetryMiddlewareConfig(initial_backoff=0.5, jitter=0.0, backoff_factor=2.0)
-        result = _calculate_backoff(1, cfg)
+        result = calculate_backoff(1, cfg)
         assert abs(result - 0.5) < 1e-9
 
     def test_exponential_growth(self) -> None:
         cfg = RetryMiddlewareConfig(initial_backoff=0.1, jitter=0.0, backoff_factor=2.0)
-        assert abs(_calculate_backoff(1, cfg) - 0.1) < 1e-9
-        assert abs(_calculate_backoff(2, cfg) - 0.2) < 1e-9
-        assert abs(_calculate_backoff(3, cfg) - 0.4) < 1e-9
+        assert abs(calculate_backoff(1, cfg) - 0.1) < 1e-9
+        assert abs(calculate_backoff(2, cfg) - 0.2) < 1e-9
+        assert abs(calculate_backoff(3, cfg) - 0.4) < 1e-9
 
     def test_max_backoff_cap(self) -> None:
         cfg = RetryMiddlewareConfig(initial_backoff=1.0, max_backoff=2.0, jitter=0.0, backoff_factor=10.0)
-        result = _calculate_backoff(5, cfg)
+        result = calculate_backoff(5, cfg)
         assert result <= 2.0
 
     def test_jitter_adds_variance(self) -> None:
         cfg = RetryMiddlewareConfig(initial_backoff=1.0, jitter=0.5, backoff_factor=1.0)
-        results = {_calculate_backoff(1, cfg) for _ in range(50)}
+        results = {calculate_backoff(1, cfg) for _ in range(50)}
         # With jitter, we should get various values
         assert len(results) > 1
 
     def test_backoff_never_negative(self) -> None:
         cfg = RetryMiddlewareConfig(initial_backoff=0.001, jitter=1.0, backoff_factor=1.0)
         for _ in range(100):
-            assert _calculate_backoff(1, cfg) >= 0.0
+            assert calculate_backoff(1, cfg) >= 0.0
 
     @pytest.mark.parametrize("factor", [1.0, 1.5, 2.0, 3.0])
     def test_various_backoff_factors(self, factor: float) -> None:
         cfg = RetryMiddlewareConfig(initial_backoff=0.1, jitter=0.0, backoff_factor=factor, max_backoff=100.0)
-        result = _calculate_backoff(3, cfg)
+        result = calculate_backoff(3, cfg)
         expected = 0.1 * math.pow(factor, 2)
         assert abs(result - expected) < 1e-9
 

--- a/packages/pykit-messaging/tests/test_adapter_scaffolds.py
+++ b/packages/pykit-messaging/tests/test_adapter_scaffolds.py
@@ -42,7 +42,7 @@ import pykit_messaging
 assert "pykit_messaging.kafka" not in sys.modules
 assert "pykit_messaging.nats" not in sys.modules
 assert "pykit_messaging.rabbitmq" not in sys.modules
-assert pykit_messaging.MessagingRegistry().producer_backends() == []
+assert pykit_messaging.MessagingRegistry().producer_adapters() == []
 """
     result = subprocess.run([sys.executable, "-c", code], check=False, capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
@@ -53,8 +53,8 @@ def test_register_kafka_is_config_free_and_creates_real_adapter_instances() -> N
 
     register_kafka(registry)
 
-    assert registry.producer_backends() == ["kafka"]
-    assert registry.consumer_backends() == ["kafka"]
+    assert registry.producer_adapters() == ["kafka"]
+    assert registry.consumer_adapters() == ["kafka"]
     producer = registry.producer(KafkaConfig(brokers=["localhost:9092"]))
     consumer = registry.consumer(KafkaConfig(topics=["events"]))
     assert isinstance(producer, KafkaProducer)
@@ -68,8 +68,8 @@ def test_register_nats_is_config_free_and_creates_real_adapter_instances() -> No
 
     register_nats(registry)
 
-    assert registry.producer_backends() == ["nats"]
-    assert registry.consumer_backends() == ["nats"]
+    assert registry.producer_adapters() == ["nats"]
+    assert registry.consumer_adapters() == ["nats"]
     producer = registry.producer(NatsConfig(url="nats://localhost:4222", allow_insecure_dev=True))
     consumer = registry.consumer(NatsConfig(topics=["events"]))
     assert isinstance(producer, NatsProducer)
@@ -127,8 +127,8 @@ def test_register_rabbitmq_is_config_free_and_creates_real_adapter_instances() -
 
     register_rabbitmq(registry)
 
-    assert registry.producer_backends() == ["rabbitmq"]
-    assert registry.consumer_backends() == ["rabbitmq"]
+    assert registry.producer_adapters() == ["rabbitmq"]
+    assert registry.consumer_adapters() == ["rabbitmq"]
     producer = registry.producer(RabbitMqConfig(url="amqp://localhost:5672", allow_insecure_dev=True))
     consumer = registry.consumer(RabbitMqConfig(topics=["events"]))
     assert isinstance(producer, RabbitMqProducer)

--- a/packages/pykit-messaging/tests/test_adapter_scaffolds.py
+++ b/packages/pykit-messaging/tests/test_adapter_scaffolds.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pykit_errors import AppError
+from pykit_messaging import MessageConsumer, MessageProducer, MessagingRegistry
+from pykit_messaging.kafka import KafkaConfig, KafkaConsumer, KafkaProducer
+from pykit_messaging.kafka import register as register_kafka
+from pykit_messaging.nats import NatsConfig, NatsConsumer, NatsProducer
+from pykit_messaging.nats import register as register_nats
+from pykit_messaging.rabbitmq import (
+    RabbitMqConfig,
+    RabbitMqConsumer,
+    RabbitMqProducer,
+)
+from pykit_messaging.rabbitmq import (
+    register as register_rabbitmq,
+)
+
+
+def test_core_import_does_not_import_optional_broker_sdks() -> None:
+    code = """
+import builtins
+import sys
+
+blocked = {"aiokafka", "nats", "aio_pika"}
+real_import = builtins.__import__
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name.split(".")[0] in blocked:
+        raise AssertionError(f"optional SDK imported: {name}")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = guarded_import
+import pykit_messaging
+assert "pykit_messaging.kafka" not in sys.modules
+assert "pykit_messaging.nats" not in sys.modules
+assert "pykit_messaging.rabbitmq" not in sys.modules
+assert pykit_messaging.MessagingRegistry().producer_backends() == []
+"""
+    result = subprocess.run([sys.executable, "-c", code], check=False, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_register_kafka_is_config_free_and_creates_real_adapter_instances() -> None:
+    registry = MessagingRegistry()
+
+    register_kafka(registry)
+
+    assert registry.producer_backends() == ["kafka"]
+    assert registry.consumer_backends() == ["kafka"]
+    producer = registry.producer(KafkaConfig(brokers=["localhost:9092"]))
+    consumer = registry.consumer(KafkaConfig(topics=["events"]))
+    assert isinstance(producer, KafkaProducer)
+    assert isinstance(consumer, KafkaConsumer)
+    assert isinstance(producer, MessageProducer)
+    assert isinstance(consumer, MessageConsumer)
+
+
+def test_register_nats_is_config_free_and_creates_real_adapter_instances() -> None:
+    registry = MessagingRegistry()
+
+    register_nats(registry)
+
+    assert registry.producer_backends() == ["nats"]
+    assert registry.consumer_backends() == ["nats"]
+    producer = registry.producer(NatsConfig(url="nats://localhost:4222", allow_insecure_dev=True))
+    consumer = registry.consumer(NatsConfig(topics=["events"]))
+    assert isinstance(producer, NatsProducer)
+    assert isinstance(consumer, NatsConsumer)
+    assert isinstance(producer, MessageProducer)
+    assert isinstance(consumer, MessageConsumer)
+
+
+def test_nats_config_repr_redacts_connection_urls() -> None:
+    cfg = NatsConfig(url="tls://broker:4222", brokers=["tls://broker:4222"], token="token-secret")
+    rendered = repr(cfg)
+    assert "token-secret" not in rendered
+    assert "user-secret" not in rendered
+    assert "url=" not in rendered
+    assert "brokers=" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_nats_producer_uses_nats_py(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = SimpleNamespace(publish=AsyncMock(), flush=AsyncMock(), close=AsyncMock())
+    fake_nats = SimpleNamespace(connect=AsyncMock(return_value=fake_client))
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> object:
+        if name == "nats":
+            return fake_nats
+        return real_import_module(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    producer = NatsProducer(NatsConfig(url="nats://broker:4222", brokers=[], allow_insecure_dev=True))
+    await producer.send("events", b"payload", key="k1", headers={"h": "v"})
+    await producer.flush()
+    await producer.close()
+
+    fake_nats.connect.assert_awaited_once_with(
+        servers=["nats://broker:4222"],
+        connect_timeout=2.0,
+        max_reconnect_attempts=3,
+        reconnect_time_wait=2.0,
+        allow_reconnect=True,
+    )
+    fake_client.publish.assert_awaited_once_with(
+        "events",
+        b"payload",
+        headers={"h": "v", "message-key": "k1"},
+    )
+    fake_client.flush.assert_awaited_once_with(timeout=30.0)
+    fake_client.close.assert_awaited_once()
+
+
+def test_register_rabbitmq_is_config_free_and_creates_real_adapter_instances() -> None:
+    registry = MessagingRegistry()
+
+    register_rabbitmq(registry)
+
+    assert registry.producer_backends() == ["rabbitmq"]
+    assert registry.consumer_backends() == ["rabbitmq"]
+    producer = registry.producer(RabbitMqConfig(url="amqp://localhost:5672", allow_insecure_dev=True))
+    consumer = registry.consumer(RabbitMqConfig(topics=["events"]))
+    assert isinstance(producer, RabbitMqProducer)
+    assert isinstance(consumer, RabbitMqConsumer)
+    assert isinstance(producer, MessageProducer)
+    assert isinstance(consumer, MessageConsumer)
+
+
+def test_rabbitmq_config_repr_redacts_connection_url() -> None:
+    cfg = RabbitMqConfig(url="amqps://broker:5671/", username="user-secret", password="password-secret")
+    rendered = repr(cfg)
+    assert "user-secret" not in rendered
+    assert "password-secret" not in rendered
+    assert "url=" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_rabbitmq_producer_uses_aio_pika(monkeypatch: pytest.MonkeyPatch) -> None:
+    published: list[tuple[object, str]] = []
+
+    class FakeMessage:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+    class FakeExchange:
+        async def publish(self, message: object, *, routing_key: str) -> None:
+            published.append((message, routing_key))
+
+    fake_exchange = FakeExchange()
+    fake_channel = SimpleNamespace(
+        default_exchange=fake_exchange,
+        close=AsyncMock(),
+    )
+    fake_connection = SimpleNamespace(
+        channel=AsyncMock(return_value=fake_channel),
+        close=AsyncMock(),
+    )
+    fake_aio_pika = SimpleNamespace(
+        Message=FakeMessage,
+        DeliveryMode=SimpleNamespace(PERSISTENT="persistent"),
+        ExchangeType=SimpleNamespace(DIRECT="direct"),
+        connect_robust=AsyncMock(return_value=fake_connection),
+    )
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> object:
+        if name == "aio_pika":
+            return fake_aio_pika
+        return real_import_module(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    producer = RabbitMqProducer(RabbitMqConfig(url="amqp://broker/", allow_insecure_dev=True))
+    await producer.send("events", b"payload", key="k1", headers={"h": "v"})
+    await producer.close()
+
+    fake_aio_pika.connect_robust.assert_awaited_once_with("amqp://broker/", timeout=30.0)
+    fake_connection.channel.assert_awaited_once_with(publisher_confirms=True)
+    assert len(published) == 1
+    message, routing_key = published[0]
+    assert routing_key == "events"
+    assert message.kwargs == {
+        "body": b"payload",
+        "headers": {"h": "v"},
+        "correlation_id": "k1",
+        "delivery_mode": "persistent",
+    }
+    fake_channel.close.assert_awaited_once()
+    fake_connection.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adapter_producers_validate_topic_before_connecting() -> None:
+    kafka_producer = KafkaProducer(KafkaConfig())
+    with pytest.raises(AppError):
+        await kafka_producer.send("bad topic", b"payload")
+
+    nats_producer = NatsProducer(NatsConfig(url="nats://broker:4222", allow_insecure_dev=True))
+    with pytest.raises(AppError):
+        await nats_producer.send("bad topic", b"payload")
+
+    rabbit_producer = RabbitMqProducer(RabbitMqConfig(url="amqp://broker/", allow_insecure_dev=True))
+    with pytest.raises(AppError):
+        await rabbit_producer.send("bad topic", b"payload")
+
+
+def test_adapter_package_imports_do_not_import_optional_broker_sdks() -> None:
+    code = """
+import builtins
+import sys
+
+blocked = {"aiokafka", "nats", "aio_pika"}
+real_import = builtins.__import__
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name.split(".")[0] in blocked:
+        raise AssertionError(f"optional SDK imported: {name}")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = guarded_import
+import pykit_messaging.kafka
+import pykit_messaging.nats
+import pykit_messaging.rabbitmq
+assert "aiokafka" not in sys.modules
+assert "nats" not in sys.modules
+assert "aio_pika" not in sys.modules
+"""
+    result = subprocess.run([sys.executable, "-c", code], check=False, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.asyncio
+async def test_missing_optional_sdk_errors_point_to_extras(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing_sdk(name: str) -> object:
+        if name in {"aiokafka", "aiokafka.errors", "nats", "aio_pika"}:
+            raise ImportError(name)
+        return importlib.import_module(name)
+
+    monkeypatch.setattr(importlib, "import_module", missing_sdk)
+
+    with pytest.raises(ImportError, match=r"pykit-messaging\[kafka\]"):
+        await KafkaProducer(KafkaConfig()).start()
+    with pytest.raises(ImportError, match=r"pykit-messaging\[nats\]"):
+        await NatsProducer(NatsConfig()).start()
+    with pytest.raises(ImportError, match=r"pykit-messaging\[rabbitmq\]"):
+        await RabbitMqProducer(RabbitMqConfig()).start()

--- a/packages/pykit-messaging/tests/test_config_redesign.py
+++ b/packages/pykit-messaging/tests/test_config_redesign.py
@@ -80,11 +80,11 @@ def test_kafka_config_validation_and_secret_redaction() -> None:
     assert cfg.brokers == ["localhost:9092"]
 
 
-def test_kafka_exactly_once_requires_transactional_id() -> None:
+def test_kafka_exactly_once_is_rejected_until_transactions_are_supported() -> None:
     with pytest.raises(AppError) as exc_info:
         KafkaConfig(delivery_guarantee=DeliveryGuarantee.EXACTLY_ONCE)
 
-    assert exc_info.value.details["field"] == "transactional_id"
+    assert exc_info.value.details["field"] == "delivery_guarantee"
 
 
 def test_nats_config_validation_defaults_and_secret_redaction() -> None:

--- a/packages/pykit-messaging/tests/test_config_redesign.py
+++ b/packages/pykit-messaging/tests/test_config_redesign.py
@@ -23,9 +23,9 @@ from pykit_messaging.rabbitmq import register as register_rabbitmq
 
 
 def test_core_broker_config_contains_only_shared_policy_and_defaults() -> None:
-    cfg = BrokerConfig(backend="  memory  ", name="")
+    cfg = BrokerConfig(adapter="  memory  ", name="")
 
-    assert cfg.backend == "memory"
+    assert cfg.adapter == "memory"
     assert cfg.name == "memory"
     assert cfg.enabled is True
     assert cfg.delivery_guarantee is DeliveryGuarantee.AT_LEAST_ONCE
@@ -43,7 +43,7 @@ def test_core_broker_config_contains_only_shared_policy_and_defaults() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "field"),
     [
-        ({"backend": ""}, "backend"),
+        ({"adapter": ""}, "adapter"),
         ({"max_in_flight": 0}, "max_in_flight"),
         ({"retries": -1}, "retries"),
         ({"request_timeout_ms": 0}, "request_timeout_ms"),
@@ -172,7 +172,7 @@ def test_memory_config_preserves_bounded_settings_and_rejects_invalid_values() -
 
 
 @pytest.mark.parametrize(
-    "backend,register",
+    "adapter,register",
     [
         ("memory", register_memory),
         ("kafka", register_kafka),
@@ -181,13 +181,13 @@ def test_memory_config_preserves_bounded_settings_and_rejects_invalid_values() -
     ],
 )
 def test_factories_reject_unsupported_exactly_once_from_core_config(
-    backend: str, register: Callable[[MessagingRegistry], None]
+    adapter: str, register: Callable[[MessagingRegistry], None]
 ) -> None:
     registry = MessagingRegistry()
     register(registry)
 
     with pytest.raises(AppError) as exc_info:
-        registry.producer(BrokerConfig(backend=backend, delivery_guarantee=DeliveryGuarantee.EXACTLY_ONCE))
+        registry.producer(BrokerConfig(adapter=adapter, delivery_guarantee=DeliveryGuarantee.EXACTLY_ONCE))
 
     assert exc_info.value.details["field"] in {"delivery_guarantee", "transactional_id"}
 

--- a/packages/pykit-messaging/tests/test_config_redesign.py
+++ b/packages/pykit-messaging/tests/test_config_redesign.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from pykit_errors import AppError
+from pykit_messaging import (
+    BrokerConfig,
+    CommitStrategy,
+    DeliveryGuarantee,
+    DLQPolicy,
+    MemoryConfig,
+    MessagingRegistry,
+)
+from pykit_messaging.kafka import KafkaConfig
+from pykit_messaging.kafka import register as register_kafka
+from pykit_messaging.memory import register as register_memory
+from pykit_messaging.nats import NatsConfig
+from pykit_messaging.nats import register as register_nats
+from pykit_messaging.rabbitmq import RabbitMqConfig
+from pykit_messaging.rabbitmq import register as register_rabbitmq
+
+
+def test_core_broker_config_contains_only_shared_policy_and_defaults() -> None:
+    cfg = BrokerConfig(backend="  memory  ", name="")
+
+    assert cfg.backend == "memory"
+    assert cfg.name == "memory"
+    assert cfg.enabled is True
+    assert cfg.delivery_guarantee is DeliveryGuarantee.AT_LEAST_ONCE
+    assert cfg.commit_strategy is CommitStrategy.POST_HANDLER_SUCCESS
+    assert cfg.dlq == DLQPolicy()
+    assert cfg.max_in_flight == 1
+    assert cfg.request_timeout_ms == 30000
+    assert cfg.retries == 3
+    assert not hasattr(cfg, "brokers")
+    assert cfg.consumer_group == ""
+    assert cfg.topics == []
+    assert cfg.subscriptions == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "field"),
+    [
+        ({"backend": ""}, "backend"),
+        ({"max_in_flight": 0}, "max_in_flight"),
+        ({"retries": -1}, "retries"),
+        ({"request_timeout_ms": 0}, "request_timeout_ms"),
+        ({"retry_backoff_ms": -1}, "retry_backoff_ms"),
+    ],
+)
+def test_core_broker_config_validation(kwargs: dict[str, object], field: str) -> None:
+    with pytest.raises(AppError) as exc_info:
+        BrokerConfig(**kwargs)
+
+    assert exc_info.value.details["field"] == field
+
+
+def test_dlq_policy_validation() -> None:
+    with pytest.raises(AppError) as exc_info:
+        DLQPolicy(enabled=True, suffix="")
+
+    assert exc_info.value.details["field"] == "dlq.suffix"
+
+
+def test_kafka_config_validation_and_secret_redaction() -> None:
+    cfg = KafkaConfig(
+        security_protocol="SASL_SSL",
+        sasl_mechanism="PLAIN",
+        sasl_username="user-secret",
+        sasl_password="password-secret",
+        transactional_id="txn-secret",
+    )
+
+    rendered = repr(cfg)
+    assert "user-secret" not in rendered
+    assert "password-secret" not in rendered
+    assert "txn-secret" not in rendered
+    assert cfg.brokers == ["localhost:9092"]
+
+
+def test_kafka_exactly_once_requires_transactional_id() -> None:
+    with pytest.raises(AppError) as exc_info:
+        KafkaConfig(delivery_guarantee=DeliveryGuarantee.EXACTLY_ONCE)
+
+    assert exc_info.value.details["field"] == "transactional_id"
+
+
+def test_nats_config_validation_defaults_and_secret_redaction() -> None:
+    cfg = NatsConfig(
+        token="token-secret",
+        url="tls://broker:4222",
+        brokers=["tls://broker:4222"],
+    )
+
+    rendered = repr(cfg)
+    assert cfg.delivery_guarantee is DeliveryGuarantee.AT_MOST_ONCE
+    assert cfg.commit_strategy is CommitStrategy.AUTO
+    assert cfg.subject("events") == "events"
+    assert "token-secret" not in rendered
+    assert "url=" not in rendered
+    assert "brokers=" not in rendered
+    assert "token=" not in rendered
+
+
+def test_nats_rejects_ack_based_shared_semantics() -> None:
+    with pytest.raises(AppError) as exc_info:
+        NatsConfig(delivery_guarantee=DeliveryGuarantee.AT_LEAST_ONCE)
+
+    assert exc_info.value.details["field"] == "delivery_guarantee"
+
+
+def test_rabbitmq_config_validation_defaults_and_secret_redaction() -> None:
+    cfg = RabbitMqConfig(url="amqps://broker:5671/", username="user-secret", password="password-secret")
+
+    rendered = repr(cfg)
+    assert cfg.delivery_guarantee is DeliveryGuarantee.AT_LEAST_ONCE
+    assert cfg.commit_strategy is CommitStrategy.POST_HANDLER_SUCCESS
+    assert cfg.auto_ack is False
+    assert cfg.routing_key("events") == "events"
+    assert "user-secret" not in rendered
+    assert "password-secret" not in rendered
+    assert "url=" not in rendered
+
+
+def test_rabbitmq_auto_ack_must_align_with_commit_strategy() -> None:
+    with pytest.raises(AppError) as exc_info:
+        RabbitMqConfig(auto_ack=True, commit_strategy=CommitStrategy.POST_HANDLER_SUCCESS)
+
+    assert exc_info.value.details["field"] == "commit_strategy"
+
+
+def test_adapter_configs_reject_plaintext_without_dev_opt_in_and_url_credentials() -> None:
+    with pytest.raises(AppError):
+        KafkaConfig(security_protocol="PLAINTEXT")
+    assert (
+        KafkaConfig(security_protocol="PLAINTEXT", allow_insecure_dev=True).security_protocol == "PLAINTEXT"
+    )
+
+    with pytest.raises(AppError):
+        NatsConfig(url="nats://broker:4222")
+    assert NatsConfig(url="nats://broker:4222", allow_insecure_dev=True).url == "nats://broker:4222"
+    with pytest.raises(AppError):
+        NatsConfig(url="tls://token-secret@broker:4222")
+
+    with pytest.raises(AppError):
+        RabbitMqConfig(url="amqp://broker:5672/")
+    assert RabbitMqConfig(url="amqp://broker:5672/", allow_insecure_dev=True).url == "amqp://broker:5672/"
+    with pytest.raises(AppError):
+        RabbitMqConfig(url="amqps://user-secret:password-secret@broker:5671/")
+
+
+def test_adapter_configs_reject_invalid_dynamic_names() -> None:
+    with pytest.raises(AppError):
+        KafkaConfig(topics=["bad topic"])
+    with pytest.raises(AppError):
+        NatsConfig(subject_prefix="bad/subject")
+    with pytest.raises(AppError):
+        RabbitMqConfig(queue_name="bad queue")
+
+
+def test_memory_config_preserves_bounded_settings_and_rejects_invalid_values() -> None:
+    cfg = MemoryConfig(capacity=8, history_limit=16, max_brokers=2)
+
+    assert cfg.capacity == 8
+    assert cfg.history_limit == 16
+    assert cfg.max_brokers == 2
+    with pytest.raises(AppError) as exc_info:
+        MemoryConfig(history_limit=0)
+    assert exc_info.value.details["field"] == "history_limit"
+
+
+@pytest.mark.parametrize(
+    "backend,register",
+    [
+        ("memory", register_memory),
+        ("kafka", register_kafka),
+        ("nats", register_nats),
+        ("rabbitmq", register_rabbitmq),
+    ],
+)
+def test_factories_reject_unsupported_exactly_once_from_core_config(
+    backend: str, register: Callable[[MessagingRegistry], None]
+) -> None:
+    registry = MessagingRegistry()
+    register(registry)
+
+    with pytest.raises(AppError) as exc_info:
+        registry.producer(BrokerConfig(backend=backend, delivery_guarantee=DeliveryGuarantee.EXACTLY_ONCE))
+
+    assert exc_info.value.details["field"] in {"delivery_guarantee", "transactional_id"}
+
+
+def test_registry_rejects_disabled_creation_time_config() -> None:
+    registry = MessagingRegistry()
+    register_memory(registry)
+
+    with pytest.raises(AppError) as exc_info:
+        registry.producer(MemoryConfig(enabled=False))
+
+    assert exc_info.value.details["field"] == "enabled"

--- a/packages/pykit-messaging/tests/test_edge_cases.py
+++ b/packages/pykit-messaging/tests/test_edge_cases.py
@@ -138,9 +138,9 @@ class TestConfigEdgeCases:
     def test_broker_config_defaults(self):
         """BrokerConfig has expected default values."""
         cfg = BrokerConfig()
-        assert cfg.name == ""
+        assert cfg.name == "memory"
         assert cfg.enabled is True
-        assert cfg.brokers == []
+        assert not hasattr(cfg, "brokers")
         assert cfg.retries == 3
         assert cfg.request_timeout_ms == 30000
 
@@ -149,22 +149,22 @@ class TestConfigEdgeCases:
         cfg = BrokerConfig(
             name="prod",
             enabled=False,
-            brokers=["broker1:9092", "broker2:9092"],
             retries=5,
             request_timeout_ms=60000,
         )
         assert cfg.name == "prod"
         assert cfg.enabled is False
-        assert len(cfg.brokers) == 2
+        assert not hasattr(cfg, "brokers")
         assert cfg.retries == 5
         assert cfg.request_timeout_ms == 60000
 
-    def test_broker_config_brokers_list_is_independent(self):
-        """Each BrokerConfig gets its own brokers list (no shared mutable default)."""
-        cfg1 = BrokerConfig()
-        cfg2 = BrokerConfig()
-        cfg1.brokers.append("broker1:9092")
-        assert cfg2.brokers == []
+    def test_broker_config_has_no_adapter_connection_fields(self):
+        """Core BrokerConfig does not carry broker-specific endpoint fields."""
+        cfg = BrokerConfig()
+        assert not hasattr(cfg, "brokers")
+        assert cfg.consumer_group == ""
+        assert cfg.topics == []
+        assert cfg.subscriptions == []
 
 
 # ── Router Edge Cases ────────────────────────────────────────────────

--- a/packages/pykit-messaging/tests/test_kafka.py
+++ b/packages/pykit-messaging/tests/test_kafka.py
@@ -33,7 +33,7 @@ class TestKafkaConfig:
         assert cfg.group_id == ""
         assert cfg.topics == []
         assert cfg.enabled is True
-        assert cfg.security_protocol == "PLAINTEXT"
+        assert cfg.security_protocol == "SSL"
         assert cfg.sasl_mechanism == ""
         assert cfg.compression_type == "snappy"
         assert cfg.auto_offset_reset == "earliest"
@@ -53,6 +53,14 @@ class TestKafkaConfig:
         assert len(cfg.brokers) == 2
         assert cfg.group_id == "test-group"
         assert cfg.sasl_mechanism == "PLAIN"
+
+    def test_repr_redacts_sasl_credentials(self) -> None:
+        cfg = KafkaConfig(sasl_username="user-secret", sasl_password="password-secret")
+        rendered = repr(cfg)
+        assert "user-secret" not in rendered
+        assert "password-secret" not in rendered
+        assert "sasl_username" not in rendered
+        assert "sasl_password" not in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/packages/pykit-messaging/tests/test_memory.py
+++ b/packages/pykit-messaging/tests/test_memory.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 
-from pykit_messaging.memory import InMemoryBroker
+from pykit_messaging import MemoryConfig, MessagingRegistry
+from pykit_messaging.memory import InMemoryBroker, InMemoryProducer, clear_memory_brokers
+from pykit_messaging.memory import register as register_memory
 from pykit_messaging.types import Event, Message
 
 
@@ -217,6 +219,62 @@ class TestInMemoryBrokerHistory:
         await producer.send_batch(msgs)
 
         assert broker.message_count("batch") == 2
+
+    async def test_history_is_bounded_to_configured_limit(self) -> None:
+        broker = InMemoryBroker(history_limit=2)
+        producer = broker.producer()
+
+        await producer.send("events", b"first")
+        await producer.send("events", b"second")
+        await producer.send("events", b"third")
+
+        assert [message.value for message in broker.all_messages()] == [b"second", b"third"]
+        assert broker.message_count("events") == 2
+
+    async def test_memory_config_history_limit_is_applied_by_registry(self) -> None:
+        registry = MessagingRegistry()
+        register_memory(registry)
+        producer = registry.producer(MemoryConfig(name="bounded", history_limit=1))
+        assert isinstance(producer, InMemoryProducer)
+
+        await producer.send("events", b"first")
+        await producer.send("events", b"second")
+
+        assert [message.value for message in producer._broker.all_messages()] == [b"second"]
+
+
+class TestMemoryRegistryState:
+    """Tests for bounded broker cache and explicit cleanup."""
+
+    async def test_registered_memory_brokers_are_bounded_by_config(self) -> None:
+        registry = MessagingRegistry()
+        register_memory(registry)
+
+        first = registry.producer(MemoryConfig(name="first", max_brokers=2))
+        second = registry.producer(MemoryConfig(name="second", max_brokers=2))
+        third = registry.producer(MemoryConfig(name="third", max_brokers=2))
+        first_again = registry.producer(MemoryConfig(name="first", max_brokers=2))
+
+        assert isinstance(first, InMemoryProducer)
+        assert isinstance(second, InMemoryProducer)
+        assert isinstance(third, InMemoryProducer)
+        assert isinstance(first_again, InMemoryProducer)
+        assert first_again._broker is not first._broker
+        assert second._broker is not third._broker
+
+    async def test_clear_memory_brokers_drops_registry_owned_brokers(self) -> None:
+        registry = MessagingRegistry()
+        register_memory(registry)
+        producer = registry.producer(MemoryConfig(name="events"))
+        assert isinstance(producer, InMemoryProducer)
+        await producer.send("events", b"payload")
+
+        clear_memory_brokers(registry)
+        replacement = registry.producer(MemoryConfig(name="events"))
+
+        assert isinstance(replacement, InMemoryProducer)
+        assert replacement._broker is not producer._broker
+        assert replacement._broker.all_messages() == []
 
 
 class TestAssertionHelpers:

--- a/packages/pykit-messaging/tests/test_middleware_circuit_breaker.py
+++ b/packages/pykit-messaging/tests/test_middleware_circuit_breaker.py
@@ -89,7 +89,7 @@ class TestCircuitBreakerHandler:
 
         # Simulate timeout
         base_time = time.monotonic()
-        with patch("pykit_messaging.middleware.circuit_breaker.time") as mock_time:
+        with patch("pykit_resilience.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = base_time + 2.0
             assert cb.state == CircuitState.HALF_OPEN
 
@@ -113,7 +113,7 @@ class TestCircuitBreakerHandler:
 
         # Simulate timeout elapsed by patching time
         base_time = time.monotonic()
-        with patch("pykit_messaging.middleware.circuit_breaker.time") as mock_time:
+        with patch("pykit_resilience.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = base_time + 2.0
             assert cb.state == CircuitState.HALF_OPEN
 
@@ -132,7 +132,7 @@ class TestCircuitBreakerHandler:
 
         # Simulate timeout elapsed to transition to half-open
         base_time = time.monotonic()
-        with patch("pykit_messaging.middleware.circuit_breaker.time") as mock_time:
+        with patch("pykit_resilience.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = base_time + 2.0
             assert cb.state == CircuitState.HALF_OPEN
 
@@ -164,7 +164,7 @@ class TestCircuitBreakerHandler:
 
         # Simulate timeout to transition to half-open
         base_time = time.monotonic()
-        with patch("pykit_messaging.middleware.circuit_breaker.time") as mock_time:
+        with patch("pykit_resilience.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = base_time + 2.0
 
             # Two probes should be allowed in half-open
@@ -190,11 +190,11 @@ class TestCircuitBreakerHandler:
         for _ in range(2):
             with pytest.raises(RuntimeError):
                 await cb.handle(_make_msg())
-        assert cb._failures == 2
+        assert cb.failures == 2
 
         # 1 success should reset failure count
         await cb.handle(_make_msg())
-        assert cb._failures == 0
+        assert cb.failures == 0
         assert cb.state == CircuitState.CLOSED
 
     async def test_circuit_breaker_middleware_factory(self) -> None:

--- a/packages/pykit-messaging/tests/test_middleware_stack.py
+++ b/packages/pykit-messaging/tests/test_middleware_stack.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from pykit_messaging.handler import FuncHandler
@@ -93,8 +95,7 @@ async def test_retry_exhausted_calls_callback() -> None:
     cfg = RetryConfig(max_attempts=2, initial_backoff=0.001, on_exhausted=on_exhausted)
     wrapped = RetryHandler(FuncHandler(always_fail), cfg)
 
-    with pytest.raises(RuntimeError, match="boom"):
-        await wrapped.handle(_make_msg())
+    await wrapped.handle(_make_msg())
 
     assert len(exhausted_msgs) == 1
 
@@ -145,6 +146,11 @@ async def test_dead_letter_sends_to_dlq() -> None:
 
     assert len(producer.sent) == 1
     assert producer.sent[0][0] == "orders.dlq"
+    envelope = json.loads(producer.sent[0][1])
+    assert envelope["original_topic"] == "orders"
+    assert envelope["error"] == "bad"
+    assert envelope["retry_count"] == 0
+    assert envelope["payload"] == "v"
 
 
 @pytest.mark.asyncio
@@ -212,3 +218,45 @@ async def test_stack_builder_fluent_api() -> None:
     # Should be able to chain all methods
     assert result1 is builder
     assert result2 is builder
+
+
+@pytest.mark.asyncio
+async def test_dead_letter_redacts_retry_count_and_sensitive_values() -> None:
+    """Test that DLQ envelopes record retry count and redact secrets."""
+    producer = MockProducer()
+    dlq = DeadLetterProducer(producer)
+    msg = Message(
+        key=None,
+        value=b"password=secret",
+        topic="orders",
+        partition=0,
+        offset=0,
+        headers={"x-retry-count": "2", "authorization": "Bearer secret", "trace-id": "abc"},
+    )
+
+    await dlq.send(msg, RuntimeError("token leaked"))
+
+    envelope = json.loads(producer.sent[0][1])
+    assert envelope["retry_count"] == 2
+    assert envelope["error"] == "<redacted>"
+    assert envelope["payload"] == "<redacted>"
+    assert envelope["headers"]["authorization"] == "<redacted>"
+    assert envelope["headers"]["trace-id"] == "abc"
+    assert b"Bearer secret" not in producer.sent[0][1]
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausted_callback_failure_propagates() -> None:
+    """Test DLQ publish failures propagate from retry exhaustion."""
+
+    async def on_exhausted(msg: Message, err: Exception) -> None:
+        raise RuntimeError("dlq failed")
+
+    async def always_fail(msg: Message) -> None:
+        raise RuntimeError("boom")
+
+    cfg = RetryConfig(max_attempts=1, initial_backoff=0.001, on_exhausted=on_exhausted)
+    wrapped = RetryHandler(FuncHandler(always_fail), cfg)
+
+    with pytest.raises(RuntimeError, match="dlq failed"):
+        await wrapped.handle(_make_msg())

--- a/packages/pykit-messaging/tests/test_middleware_stack.py
+++ b/packages/pykit-messaging/tests/test_middleware_stack.py
@@ -83,7 +83,7 @@ async def test_retry_succeeds_after_failures() -> None:
 
 @pytest.mark.asyncio
 async def test_retry_exhausted_calls_callback() -> None:
-    """Test that exhaustion callback is called when retries are exhausted."""
+    """Test that exhaustion callback is called and error is re-raised."""
     exhausted_msgs: list[Message] = []
 
     async def on_exhausted(msg: Message, err: Exception) -> None:
@@ -95,7 +95,8 @@ async def test_retry_exhausted_calls_callback() -> None:
     cfg = RetryConfig(max_attempts=2, initial_backoff=0.001, on_exhausted=on_exhausted)
     wrapped = RetryHandler(FuncHandler(always_fail), cfg)
 
-    await wrapped.handle(_make_msg())
+    with pytest.raises(RuntimeError, match="boom"):
+        await wrapped.handle(_make_msg())
 
     assert len(exhausted_msgs) == 1
 

--- a/packages/pykit-messaging/tests/test_registry.py
+++ b/packages/pykit-messaging/tests/test_registry.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pykit_errors import AppError
+from pykit_messaging import BrokerConfig, InMemoryProducer, MemoryConfig, MessagingRegistry
+from pykit_messaging.memory import register as register_memory
+from pykit_messaging.types import Message
+
+
+class DummyProducer:
+    async def send(
+        self,
+        topic: str,
+        value: bytes,
+        key: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        pass
+
+    async def send_event(self, topic: str, event: object) -> None:
+        pass
+
+    async def send_json(self, topic: str, data: object, key: str | None = None) -> None:
+        pass
+
+    async def send_batch(self, messages: list[Message]) -> None:
+        pass
+
+    async def flush(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+class DummyConsumer:
+    async def subscribe(self, topics: list[str]) -> None:
+        pass
+
+    async def consume(self, handler: object) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+def test_registry_starts_empty_and_has_no_side_effects() -> None:
+    registry = MessagingRegistry()
+
+    assert registry.producer_backends() == []
+    assert registry.consumer_backends() == []
+    with pytest.raises(AppError):
+        registry.producer(BrokerConfig(backend="kafka"))
+
+
+def test_register_memory_backend_is_config_free() -> None:
+    registry = MessagingRegistry()
+
+    register_memory(registry)
+
+    assert registry.producer_backends() == ["memory"]
+    assert registry.consumer_backends() == ["memory"]
+    config = MemoryConfig(name="events", topics=["events"])
+    assert registry.producer(config) is not None
+    assert registry.consumer(config) is not None
+
+
+def test_factories_are_invoked_with_creation_time_config() -> None:
+    registry = MessagingRegistry()
+    producer_configs: list[BrokerConfig] = []
+    consumer_configs: list[BrokerConfig] = []
+
+    registry.register_producer("dummy", lambda config: producer_configs.append(config) or DummyProducer())
+    registry.register_consumer("dummy", lambda config: consumer_configs.append(config) or DummyConsumer())
+
+    first = BrokerConfig(backend="dummy", name="first")
+    second = BrokerConfig(backend="dummy", name="second")
+
+    registry.producer(first)
+    registry.consumer(second)
+
+    assert producer_configs == [first]
+    assert consumer_configs == [second]
+
+
+@pytest.mark.asyncio
+async def test_memory_registry_supports_multiple_configs_without_reregistration() -> None:
+    registry = MessagingRegistry()
+    register_memory(registry)
+
+    first = MemoryConfig(name="first", topics=["events"])
+    second = MemoryConfig(name="second", topics=["events"])
+
+    first_producer = registry.producer(first)
+    first_consumer = registry.consumer(first)
+    second_producer = registry.producer(second)
+    second_consumer = registry.consumer(second)
+
+    assert isinstance(first_producer, InMemoryProducer)
+    assert isinstance(second_producer, InMemoryProducer)
+
+    await first_producer.send("events", b"first")
+    await second_producer.send("events", b"second")
+
+    first_received: list[Message] = []
+    second_received: list[Message] = []
+
+    async def first_handler(message: Message) -> None:
+        first_received.append(message)
+        await first_consumer.close()
+
+    async def second_handler(message: Message) -> None:
+        second_received.append(message)
+        await second_consumer.close()
+
+    await asyncio.gather(first_consumer.consume(first_handler), second_consumer.consume(second_handler))
+
+    assert [message.value for message in first_received] == [b"first"]
+    assert [message.value for message in second_received] == [b"second"]
+
+
+def test_duplicate_registration_is_rejected() -> None:
+    registry = MessagingRegistry()
+    register_memory(registry)
+
+    with pytest.raises(AppError):
+        register_memory(registry)

--- a/packages/pykit-messaging/tests/test_registry.py
+++ b/packages/pykit-messaging/tests/test_registry.py
@@ -50,19 +50,19 @@ class DummyConsumer:
 def test_registry_starts_empty_and_has_no_side_effects() -> None:
     registry = MessagingRegistry()
 
-    assert registry.producer_backends() == []
-    assert registry.consumer_backends() == []
+    assert registry.producer_adapters() == []
+    assert registry.consumer_adapters() == []
     with pytest.raises(AppError):
-        registry.producer(BrokerConfig(backend="kafka"))
+        registry.producer(BrokerConfig(adapter="kafka"))
 
 
-def test_register_memory_backend_is_config_free() -> None:
+def test_register_memory_adapter_is_config_free() -> None:
     registry = MessagingRegistry()
 
     register_memory(registry)
 
-    assert registry.producer_backends() == ["memory"]
-    assert registry.consumer_backends() == ["memory"]
+    assert registry.producer_adapters() == ["memory"]
+    assert registry.consumer_adapters() == ["memory"]
     config = MemoryConfig(name="events", topics=["events"])
     assert registry.producer(config) is not None
     assert registry.consumer(config) is not None
@@ -76,8 +76,8 @@ def test_factories_are_invoked_with_creation_time_config() -> None:
     registry.register_producer("dummy", lambda config: producer_configs.append(config) or DummyProducer())
     registry.register_consumer("dummy", lambda config: consumer_configs.append(config) or DummyConsumer())
 
-    first = BrokerConfig(backend="dummy", name="first")
-    second = BrokerConfig(backend="dummy", name="second")
+    first = BrokerConfig(adapter="dummy", name="first")
+    second = BrokerConfig(adapter="dummy", name="second")
 
     registry.producer(first)
     registry.consumer(second)

--- a/packages/pykit-resilience/src/pykit_resilience/__init__.py
+++ b/packages/pykit-resilience/src/pykit_resilience/__init__.py
@@ -22,6 +22,7 @@ from pykit_resilience.retry import (
     LinearBackoff,
     RetryConfig,
     RetryExhaustedError,
+    calculate_backoff,
     retry,
 )
 
@@ -46,5 +47,6 @@ __all__ = [
     "ServiceHealth",
     "ServiceStatus",
     "State",
+    "calculate_backoff",
     "retry",
 ]

--- a/packages/pykit-resilience/src/pykit_resilience/retry.py
+++ b/packages/pykit-resilience/src/pykit_resilience/retry.py
@@ -82,6 +82,11 @@ def _calculate_backoff(attempt: int, config: RetryConfig) -> float:
     return max(backoff, 0.0)
 
 
+def calculate_backoff(attempt: int, config: RetryConfig) -> float:
+    """Return the canonical retry backoff for a one-based failed attempt."""
+    return _calculate_backoff(attempt, config)
+
+
 async def retry[T](
     fn: Callable[[], Awaitable[T]],
     config: RetryConfig | None = None,

--- a/packages/pykit-resilience/tests/test_resilience.py
+++ b/packages/pykit-resilience/tests/test_resilience.py
@@ -21,6 +21,7 @@ from pykit_resilience import (
     RetryConfig,
     RetryExhaustedError,
     State,
+    calculate_backoff,
     retry,
 )
 
@@ -356,6 +357,10 @@ class TestRetry:
         assert cfg.max_backoff == 10.0
         assert cfg.backoff_factor == 2.0
         assert cfg.jitter == 0.1
+
+    def test_calculate_backoff_is_public(self) -> None:
+        cfg = RetryConfig(initial_backoff=0.1, max_backoff=0.25, backoff_factor=2.0, jitter=0.0)
+        assert calculate_backoff(3, cfg) == 0.25
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,19 @@ constraints = [
 ]
 
 [[package]]
+name = "aio-pika"
+version = "9.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiormq" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/63/56354526f2e6e915c93bee6e4dedb35888fe82d6bc1a19f35f5a77e795ff/aio_pika-9.6.2.tar.gz", hash = "sha256:c49e9246080dc8ffa1bb0e4aca407bf3d8ad78c3ee3a93df88b68fe65d7a49b9", size = 70851, upload-time = "2026-03-22T19:03:20.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/05/256fa313f48bed075056d13593b92ce804be05d75f4f312be24edb82860a/aio_pika-9.6.2-py3-none-any.whl", hash = "sha256:2a5478af920d169795071c9c09c7542cd8cdece60438cf7804533dcbcce93b7f", size = 56269, upload-time = "2026-03-22T19:03:19.558Z" },
+]
+
+[[package]]
 name = "aioboto3"
 version = "15.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -240,6 +253,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/c4/9841118a2157e913e8ebfbc0a2b58f7b60f1f7202040c3e1df8925ed1184/aiokafka-0.14.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cd651e1f56571baae306fdd0b5509047ab9625797a24cd75902e139c5a20318", size = 1098571, upload-time = "2026-04-29T10:42:59.356Z" },
     { url = "https://files.pythonhosted.org/packages/d6/a1/0af8a37849a4108ae227f46c4c62f6beab31863cf66ba318fb73b0be5b26/aiokafka-0.14.0-cp314-cp314-win32.whl", hash = "sha256:128127eb96dab98150b636bb5f480c80e15f02f82a118eec206a521c8cf7cf7c", size = 314107, upload-time = "2026-04-29T10:43:01.111Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/fb46c65f758900c71d0f1c73b7802720f99cabcb1f4a11676573f9bc1b8f/aiokafka-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:aa385039aa9b235359319bbdcf48c9c86a75d81c9c547d645056d00361238903", size = 333320, upload-time = "2026-04-29T10:43:02.424Z" },
+]
+
+[[package]]
+name = "aiormq"
+version = "6.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pamqp" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0e/db90154d52d399108903fe603e5110a533c42065180265dd003788264080/aiormq-6.9.4.tar.gz", hash = "sha256:0e7c01b662804e1cc7ace9a17794e8c1192a27fc2afa96162362a6e61ae8e8ef", size = 49232, upload-time = "2026-03-23T09:18:19.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/48/1ce3773f392f02ceda37aee168fade9d725483a9592c202d06044cd093ff/aiormq-6.9.4-py3-none-any.whl", hash = "sha256:726a8586695e863fba68cf88842065ab12348c9438dcebdfc9d0bddaf6083277", size = 32166, upload-time = "2026-03-23T09:18:17.523Z" },
 ]
 
 [[package]]
@@ -1580,6 +1606,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nats-py"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/f8/b956c4621ba88748ed707c52e69f95b7a50c8914e750edca59a5bef84a76/nats_py-2.14.0.tar.gz", hash = "sha256:4ed02cb8e3b55c68074a063aa2687087115d805d1513297da90cb2068fb07bed", size = 120751, upload-time = "2026-02-23T22:44:58.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl", hash = "sha256:4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d", size = 82259, upload-time = "2026-02-23T22:45:00.152Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1736,6 +1771,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pamqp"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/62/35bbd3d3021e008606cd0a9532db7850c65741bbf69ac8a3a0d8cfeb7934/pamqp-3.3.0.tar.gz", hash = "sha256:40b8795bd4efcf2b0f8821c1de83d12ca16d5760f4507836267fd7a02b06763b", size = 30993, upload-time = "2024-01-12T20:37:25.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/8d/c1e93296e109a320e508e38118cf7d1fc2a4d1c2ec64de78565b3c445eb5/pamqp-3.3.0-py2.py3-none-any.whl", hash = "sha256:c901a684794157ae39b52cbf700db8c9aae7a470f13528b9d7b4e5f7202f8eb0", size = 33848, upload-time = "2024-01-12T20:37:21.359Z" },
 ]
 
 [[package]]
@@ -2744,6 +2788,7 @@ dependencies = [
     { name = "pykit-component" },
     { name = "pykit-errors" },
     { name = "pykit-observability" },
+    { name = "pykit-resilience" },
     { name = "pykit-util" },
 ]
 
@@ -2758,21 +2803,30 @@ kafka = [
     { name = "aiokafka" },
     { name = "cramjam" },
 ]
+nats = [
+    { name = "nats-py" },
+]
+rabbitmq = [
+    { name = "aio-pika" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=9.5" },
     { name = "aiokafka", marker = "extra == 'kafka'" },
     { name = "cramjam", marker = "extra == 'kafka'" },
+    { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.10" },
     { name = "pykit-component", editable = "packages/pykit-component" },
     { name = "pykit-dag", marker = "extra == 'bridges'", editable = "packages/pykit-dag" },
     { name = "pykit-errors", editable = "packages/pykit-errors" },
     { name = "pykit-observability", editable = "packages/pykit-observability" },
     { name = "pykit-pipeline", marker = "extra == 'bridges'", editable = "packages/pykit-pipeline" },
     { name = "pykit-provider", marker = "extra == 'bridges'", editable = "packages/pykit-provider" },
+    { name = "pykit-resilience", editable = "packages/pykit-resilience" },
     { name = "pykit-util", editable = "packages/pykit-util" },
     { name = "pykit-worker", marker = "extra == 'bridges'", editable = "packages/pykit-worker" },
 ]
-provides-extras = ["kafka", "bridges"]
+provides-extras = ["kafka", "nats", "rabbitmq", "bridges"]
 
 [[package]]
 name = "pykit-observability"
@@ -3147,7 +3201,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aiokafka", specifier = ">=0.13.0" },
+    { name = "aiokafka", specifier = ">=0.14.0" },
     { name = "aiosqlite" },
     { name = "argon2-cffi", specifier = ">=25.1.0" },
     { name = "cramjam", specifier = ">=2.11.0" },


### PR DESCRIPTION
## Description

Rework `pykit-messaging` around a clean core registry plus opt-in Kafka, NATS, and RabbitMQ adapters. Core imports stay dependency-light, while adapter modules own their SDK imports, protocol config, validation, redaction, and lifecycle behavior.

## Motivation

Applications should be able to use in-memory or core messaging without installing broker SDKs or inheriting Kafka-specific assumptions. This matches the cache/storage optional-adapter pattern and keeps adapter choices explicit at the application boundary.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test coverage improvement

## Package(s) Affected

- `pykit-messaging`
- `pykit-resilience`

## Changes Made

- Added config-free adapter registration with creation-time config and clean optional SDK boundaries.
- Added real NATS and RabbitMQ adapters with typed config, validation, redaction, and async lifecycle handling.
- Kept provider integration shape-specific: producers compose as `Sink[Message]` and consumers compose as `Stream[None, Message]`.
- Bounded in-memory broker cache/history and added cleanup support for tests.
- Aligned retry, DLQ, circuit breaker, and middleware behavior with canonical resilience/messaging patterns.

## Testing

- [x] Added new tests for my changes
- [ ] All existing tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check packages/`)
- [ ] Type-check passes (`uv run mypy packages/`)
- [ ] Import layering passes (`uv run lint-imports`)
- [ ] Manual testing performed (describe below if applicable)

### Test Evidence

```
$ uv run ruff format --check packages/pykit-messaging
# passed

$ uv run ruff check packages/pykit-messaging
# passed

$ uv run pytest packages/pykit-messaging/tests
# 280 passed

$ python -c 'import pykit_messaging'
# passed without optional broker SDKs
```

## Breaking Changes

Messaging adapter setup now uses explicit adapter registration and adapter-specific config types. Code that imported Kafka behavior from the core package should import/register the adapter module instead.

## Sibling Parity

Parity is implemented in the matching Go and Rust PRs. Go PR: https://github.com/kbukum/gokit/pull/137; Rust PR: https://github.com/kbukum/rskit/pull/137

- [ ] Sibling-parity not required (internal change)
- [x] Sibling-parity tracked in matching gokit and rskit PRs

## Checklist

- [x] My code follows the [coding standards](../CONTRIBUTING.md#code-style) in CONTRIBUTING.md
- [x] I have run `uv lock` and committed `uv.lock` if dependencies changed
- [x] I have added Google-style docstrings for new public functions/classes
- [x] I have updated relevant documentation (README.md, package README, etc.)
- [x] I have added tests that prove my fix/feature works
- [x] I have considered backward compatibility
- [x] New dependencies (if any) are justified and minimal
- [ ] CHANGELOG entry added under `[Unreleased]`

## Additional Notes

Review focus: optional import boundaries, adapter config validation, provider-shape bridge behavior, and the shared DLQ/retry behavior reused by Kafka/NATS/RabbitMQ.
